### PR TITLE
Drop ResNet support to reflect ViT-B-only MAE

### DIFF
--- a/Classification/eval_classification.py
+++ b/Classification/eval_classification.py
@@ -98,23 +98,13 @@ def build(args):
     if args.pretraining in ["Hyperkvasir", "ImageNet_self"]:
         model = utils.get_MAE_backbone(None, True, n_class, False, None)
     elif args.pretraining == "ImageNet_class":
-        if args.arch == "resnet50":
-            model = utils.get_ImageNet_or_random_ResNet(
-                True, n_class, False, None, ImageNet_weights=True
-            )
-        else:
-            model = utils.get_ImageNet_or_random_ViT(
-                True, n_class, False, None, ImageNet_weights=True
-            )
+        model = utils.get_ImageNet_or_random_ViT(
+            True, n_class, False, None, ImageNet_weights=True
+        )
     elif args.pretraining == "random":
-        if args.arch == "resnet50":
-            model = utils.get_ImageNet_or_random_ResNet(
-                True, n_class, False, None, ImageNet_weights=False
-            )
-        else:
-            model = utils.get_ImageNet_or_random_ViT(
-                True, n_class, False, None, ImageNet_weights=False
-            )
+        model = utils.get_ImageNet_or_random_ViT(
+            True, n_class, False, None, ImageNet_weights=False
+        )
     if args.ss_framework:
         ckpt_path = f"Trained models/{args.arch}-{args.pretraining}_{args.ss_framework}_init-frozen_{str(False)}-dataset_{args.dataset}.pth"
     else:
@@ -143,8 +133,8 @@ def get_args():
     parser.add_argument(
         "--architecture",
         type=str,
-        required=True,
-        choices=["resnet50", "vit_b"],
+        choices=["vit_b"],
+        default="vit_b",
         dest="arch",
     )
     parser.add_argument(

--- a/Classification/train_classification.py
+++ b/Classification/train_classification.py
@@ -174,23 +174,13 @@ def build(args, rank):
             args.ckpt, True, n_class, args.frozen, None
         )
     elif args.pretraining == "ImageNet_class":
-        if args.arch == "resnet50":
-            model = utils.get_ImageNet_or_random_ResNet(
-                True, n_class, args.frozen, None, ImageNet_weights=True
-            )
-        else:
-            model = utils.get_ImageNet_or_random_ViT(
-                True, n_class, args.frozen, None, ImageNet_weights=True
-            )
+        model = utils.get_ImageNet_or_random_ViT(
+            True, n_class, args.frozen, None, ImageNet_weights=True
+        )
     elif args.pretraining == "random":
-        if args.arch == "resnet50":
-            model = utils.get_ImageNet_or_random_ResNet(
-                True, n_class, args.frozen, None, ImageNet_weights=False
-            )
-        else:
-            model = utils.get_ImageNet_or_random_ViT(
-                True, n_class, args.frozen, None, ImageNet_weights=False
-            )
+        model = utils.get_ImageNet_or_random_ViT(
+            True, n_class, args.frozen, None, ImageNet_weights=False
+        )
     if args.ss_framework:
         ckpt_path = f"Trained models/{args.arch}-{args.pretraining}_{args.ss_framework}_init-frozen_{str(args.frozen)}-dataset_{args.dataset}.pth"
         log_path = f"Trained models/{args.arch}-{args.pretraining}_{args.ss_framework}_init-frozen_{str(args.frozen)}-dataset_{args.dataset}.txt"
@@ -367,8 +357,8 @@ def get_args():
     parser.add_argument(
         "--architecture",
         type=str,
-        required=True,
-        choices=["resnet50", "vit_b"],
+        choices=["vit_b"],
+        default="vit_b",
         dest="arch",
     )
     parser.add_argument(

--- a/Models/models.py
+++ b/Models/models.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn as nn
-import torchvision
 
 from functools import partial
 from timm.models.vision_transformer import VisionTransformer
@@ -9,147 +8,6 @@ from timm.models.hub import download_cached_file
 from .mae import models_mae
 
 from .DPT_decoder import DPT_decoder
-
-
-class ResNet_Dec_Block(nn.Module):
-    def __init__(self, channels, fusion=False):
-        super(ResNet_Dec_Block, self).__init__()
-        if fusion:
-            self.identity = nn.Sequential(
-                nn.Conv2d(channels * 2, channels, 1), nn.BatchNorm2d(channels)
-            )
-            conv1 = nn.Conv2d(channels * 2, channels // 4, 1)
-        else:
-            self.identity = nn.Identity()
-            conv1 = nn.Conv2d(channels, channels // 4, 1)
-        self.process = nn.Sequential(
-            conv1,
-            nn.BatchNorm2d(channels // 4),
-            nn.ReLU(),
-            nn.Conv2d(channels // 4, channels // 4, 3, padding=1),
-            nn.BatchNorm2d(channels // 4),
-            nn.ReLU(),
-            nn.Conv2d(channels // 4, channels, 1),
-            nn.BatchNorm2d(channels),
-        )
-        self.relu = nn.ReLU()
-
-    def forward(self, x):
-        identity = self.identity(x)
-        x = self.process(x)
-        x += identity
-        return self.relu(x)
-
-
-class ResNet_Dec_Level(nn.Module):
-    def __init__(self, channels, n_blocks):
-        super(ResNet_Dec_Level, self).__init__()
-        self.chan_reduce = nn.Sequential(
-            nn.Conv2d(channels * 2, channels, 1), nn.BatchNorm2d(channels)
-        )
-        self.up = nn.Upsample(scale_factor=2, mode="bilinear", align_corners=True)
-        blocks = [ResNet_Dec_Block(channels, fusion=True)]
-        for _ in range(1, n_blocks):
-            blocks.append(ResNet_Dec_Block(channels, fusion=False))
-        self.blocks = nn.Sequential(*blocks)
-
-    def forward(self, x_low, x_high):
-        x = torch.cat((self.up(self.chan_reduce(x_low)), x_high), 1)
-        return self.blocks(x)
-
-
-class ResNet_from_Any(torchvision.models.resnet.ResNet):
-    def __init__(
-        self, weight_path, head, num_classes, frozen, dense, ImageNet_weights=False
-    ):
-        super(ResNet_from_Any, self).__init__(
-            torchvision.models.resnet.Bottleneck, [3, 4, 6, 3]
-        )
-        if ImageNet_weights:
-            state_dict = torchvision.models.utils.load_state_dict_from_url(
-                "https://download.pytorch.org/models/resnet50-19c8e357.pth",
-                progress=True,
-            )
-            self.load_state_dict(state_dict)
-
-        self.fc = nn.Identity()
-        if weight_path is not None:
-            weights = torch.load(weight_path, map_location="cpu")
-            self.load_state_dict(weights)
-
-        self.head = head
-        if head:
-            self.lin_head = nn.Linear(2048, num_classes)
-        self.frozen = frozen
-        self.dense = dense
-
-        if self.dense:
-            self.decoder_levels = nn.ModuleList(
-                [
-                    ResNet_Dec_Level(1024, 3),
-                    ResNet_Dec_Level(512, 3),
-                    ResNet_Dec_Level(256, 3),
-                ]
-            )
-            self.output_conv = nn.Sequential(
-                nn.Upsample(scale_factor=2, mode="bilinear", align_corners=True),
-                nn.Conv2d(256, 128, kernel_size=3, stride=1, padding=1),
-                nn.Upsample(scale_factor=2, mode="bilinear", align_corners=True),
-                nn.Conv2d(128, 32, kernel_size=3, stride=1, padding=1),
-                nn.ReLU(True),
-                nn.Conv2d(32, 1, kernel_size=1, stride=1, padding=0),
-                nn.Sigmoid(),
-            )
-
-    def forward_features(self, x):
-        if self.dense:
-            fmaps = []
-        x = self.conv1(x)
-        x = self.bn1(x)
-        x = self.relu(x)
-        x = self.maxpool(x)
-
-        x = self.layer1(x)
-        if self.dense:
-            fmaps.append(x)
-        x = self.layer2(x)
-        if self.dense:
-            fmaps.append(x)
-        x = self.layer3(x)
-        if self.dense:
-            fmaps.append(x)
-        x = self.layer4(x)
-        if self.dense:
-            fmaps.append(x)
-        return x if not self.dense else fmaps
-
-    def decode(self, x):
-        out = self.decoder_levels[0](x[-1], x[-2])
-        for i in range(1, len(self.decoder_levels)):
-            out = self.decoder_levels[i](out, x[-i - 2])
-
-        out = self.output_conv(out)
-
-        return out
-
-    def _forward_impl(self, x):
-        if self.frozen:
-            with torch.no_grad():
-                x = self.forward_features(x)
-        else:
-            x = self.forward_features(x)
-        if not self.dense:
-            x = self.avgpool(x)
-            x = torch.flatten(x, 1)
-            x = self.fc(x)
-            if self.head:
-                x = self.lin_head(x)
-        else:
-            x = self.decode(x)
-
-        return x
-
-
 
 
 class VisionTransformer_from_Any(VisionTransformer):
@@ -300,6 +158,4 @@ class ViT_from_MAE(models_mae.MaskedAutoencoderViT):
             if self.head:
                 x = self.lin_head(x)
         return x
-
-
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Links to the paper:
 
 ## 1. Abstract
 
-Solutions to vision tasks in gastrointestinal endoscopy (GIE) conventionally use image encoders pretrained in a supervised manner with ImageNet-1k as backbones. However, the use of modern self-supervised pretraining algorithms and a recent dataset of 100k unlabelled GIE images (Hyperkvasir-unlabelled) may allow for improvements. In this work, we study the fine-tuned performance of models with ResNet50 and ViT-B backbones pretrained in self-supervised and supervised manners with ImageNet-1k and Hyperkvasir-unlabelled (self-supervised only) in a range of GIE vision tasks. In addition to identifying the most suitable pretraining pipeline and backbone architecture for each task, out of those considered, our results suggest three general principles. Firstly, that self-supervised pretraining generally produces more suitable backbones for GIE vision tasks than supervised pretraining. Secondly, that self-supervised pretraining with ImageNet-1k is typically more suitable than pretraining with Hyperkvasir-unlabelled. Thirdly, that ViT-Bs are more suitable in polyp segmentation and monocular depth estimation in colonoscopy, ResNet50s are more suitable in polyp detection, and both architectures perform similarly in anatomical landmark recognition and pathological finding characterisation. We hope this work draws attention to the complexity of pretraining for GIE vision tasks, informs this development of more suitable approaches than the convention, and inspires further research on this topic to help advance this development.
+Solutions to vision tasks in gastrointestinal endoscopy (GIE) conventionally use image encoders pretrained in a supervised manner with ImageNet-1k as backbones. However, the use of modern self-supervised pretraining algorithms and a recent dataset of 100k unlabelled GIE images (Hyperkvasir-unlabelled) may allow for improvements. In this work, we study the fine-tuned performance of ViT-B backbones pretrained in self-supervised and supervised manners with ImageNet-1k and Hyperkvasir-unlabelled (self-supervised only) in a range of GIE vision tasks. In addition to identifying the most suitable pretraining pipeline for each task, out of those considered, our results suggest three general principles. Firstly, that self-supervised pretraining generally produces more suitable backbones for GIE vision tasks than supervised pretraining. Secondly, that self-supervised pretraining with ImageNet-1k is typically more suitable than pretraining with Hyperkvasir-unlabelled. Thirdly, that ViT-Bs are more suitable in polyp segmentation and monocular depth estimation in colonoscopy and perform similarly to alternative architectures in anatomical landmark recognition and pathological finding characterisation. We hope this work draws attention to the complexity of pretraining for GIE vision tasks, informs this development of more suitable approaches than the convention, and inspires further research on this topic to help advance this development.
 
 ## 2. Usage
 
@@ -17,7 +17,7 @@ Solutions to vision tasks in gastrointestinal endoscopy (GIE) conventionally use
 
 Follow the guidance in this section for obtaining the weights for pretrained models.
 
-+ For encoders pretrained in a supervised manner with ImageNet-1k, the weights provided with the [torchvision](https://pytorch.org/vision/stable/index.html) (ResNet50) and [timm](https://timm.fast.ai/) (ViT-B) libraries are automatically used by our code and no manual steps are required.
++ For encoders pretrained in a supervised manner with ImageNet-1k, the weights provided with the [timm](https://timm.fast.ai/) library (ViT-B) are automatically used by our code and no manual steps are required.
 + For encoders pretrained in a self-supervised manner with ImageNet-1k, using [MAE](https://github.com/facebookresearch/mae), the weights provided with the codebase should be used.
 + For encoders pretrained in a self-supervised manner with [Hyperkvasir-unlabelled](https://datasets.simula.no/hyper-kvasir/), using [MAE](https://github.com/facebookresearch/mae), the codebase should be used for pretraining. The code should first be modified to allow pretraining with Hyperkvasir-unabelled (remove `'/train'` from data path) and the guidance in the respective codebase for running the pretraining should then be followed with any arguments adjusted for your given hardware as needed.
 
@@ -52,7 +52,7 @@ python train_classification.py \
     --batch-size [batch-size]
 ```
 
-* Replace `[architecture]` with name of encoder architecture (`resnet50` or `vit_b`).
+* Replace `[architecture]` with name of encoder architecture (`vit_b`).
 * Replace `[pretraining]` with general pretraining methodology (`Hyperkvasir`, `ImageNet_self`, `ImageNet_class`, or `random`).
 * For models pretrained in a self-supervised manner, replace `[ss-framework]` with pretraining algorithm `mae` and `[checkpoint]` with path to pretrained weights (classification only).
 * Replace `[dataset]` with name of dataset (e.g., `Hyperkvasir_anatomical` or `Hyperkvasir_pathological`).
@@ -88,7 +88,7 @@ python eval_classification.py \
     --data-root [data-root]
 ```
 
-* Replace `[architecture]` with name of encoder architecture (`resnet50` or `vit_b`).
+* Replace `[architecture]` with name of encoder architecture (`vit_b`).
 * Replace `[pretraining]` with general pretraining methodology (`Hyperkvasir`, `ImageNet_self`, `ImageNet_class`, or `random`).
 * For models pretrained in a self-supervised manner, replace `[ss-framework]` with pretraining algorithm `mae`.
 * Replace `[dataset]` with name of dataset (e.g., `Hyperkvasir_anatomical` or `Hyperkvasir_pathological`).

--- a/utils.py
+++ b/utils.py
@@ -15,12 +15,6 @@ def get_MAE_backbone(weight_path, head, num_classes, frozen, dense, out_token="c
     )
 
 
-def get_ImageNet_or_random_ResNet(head, num_classes, frozen, dense, ImageNet_weights):
-    return models.ResNet_from_Any(
-        None, head, num_classes, frozen, dense, ImageNet_weights
-    )
-
-
 def get_ImageNet_or_random_ViT(
     head,
     num_classes,


### PR DESCRIPTION
## Summary
- remove ResNet model implementations and utilities
- simplify classification scripts to always use ViT-B
- update docs to reflect ViT-B is the only supported architecture

## Testing
- `python -m py_compile utils.py Classification/train_classification.py Classification/eval_classification.py Models/models.py`
- `python train_classification.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `python eval_classification.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68a99cb43778832ea51714a9ea0a5a26