### PR TITLE
Add helper script to run all pretraining configurations

### DIFF
--- a/Classification/run_all_pretrainings.py
+++ b/Classification/run_all_pretrainings.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Utility to fine-tune ViT-B/16 under all pretraining schemes.
+
+This script sequentially launches ``train_classification.py`` for the
+three pretraining modes used in the paper:
+
+* SUP-imnet  – supervised ImageNet-1k weights.
+* SSL-imnet – MAE self-supervised ImageNet-1k weights.
+* SSL-colon – MAE self-supervised Hyperkvasir-unlabelled weights.
+
+Checkpoints for the self-supervised options must be supplied via the
+command line. Fine-tuned models are stored in
+``Classification/Trained models`` as usual.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from typing import List
+
+
+def run(cmd: List[str]) -> None:
+    """Run a subprocess and stream its output."""
+    print("Running:", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fine-tune ViT-B/16 for all pretraining configurations"
+    )
+    parser.add_argument(
+        "--dataset", required=True, help="Dataset tag, e.g. Hyperkvasir_pathological"
+    )
+    parser.add_argument(
+        "--data-root", required=True, help="Path to the dataset root directory"
+    )
+    parser.add_argument(
+        "--imagenet-mae",
+        required=True,
+        help="Checkpoint for MAE pretraining on ImageNet-1k (SSL-imnet)",
+    )
+    parser.add_argument(
+        "--hyperkvasir-mae",
+        required=True,
+        help="Checkpoint for MAE pretraining on Hyperkvasir-unlabelled (SSL-colon)",
+    )
+    parser.add_argument("--arch", default="vit_b", help="Backbone architecture")
+    parser.add_argument(
+        "--batch-size", type=int, default=16, help="Batch size for each run"
+    )
+    parser.add_argument(
+        "--extra-args",
+        default="",
+        help="Additional arguments passed to train_classification.py",
+    )
+    args = parser.parse_args()
+
+    script = os.path.join(os.path.dirname(__file__), "train_classification.py")
+
+    base_cmd = [
+        sys.executable,
+        script,
+        "--architecture",
+        args.arch,
+        "--dataset",
+        args.dataset,
+        "--data-root",
+        args.data_root,
+        "--batch-size",
+        str(args.batch_size),
+        "--learning-rate-scheduler",
+    ]
+    extra = args.extra_args.split()
+
+    # SUP-imnet: supervised ImageNet baseline
+    run(base_cmd + ["--pretraining", "ImageNet_class"] + extra)
+
+    # SSL-imnet: MAE on ImageNet-1k
+    run(
+        base_cmd
+        + [
+            "--pretraining",
+            "ImageNet_self",
+            "--ss-framework",
+            "mae",
+            "--checkpoint",
+            args.imagenet_mae,
+        ]
+        + extra
+    )
+
+    # SSL-colon: MAE on Hyperkvasir-unlabelled
+    run(
+        base_cmd
+        + [
+            "--pretraining",
+            "Hyperkvasir",
+            "--ss-framework",
+            "mae",
+            "--checkpoint",
+            args.hyperkvasir_mae,
+        ]
+        + extra
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/Models/mae/main_pretrain.py
+++ b/Models/mae/main_pretrain.py
@@ -22,6 +22,17 @@ from torch.utils.tensorboard import SummaryWriter
 import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 
+import types
+import collections
+import sys
+
+if "torch._six" not in sys.modules:
+    module = types.ModuleType("torch._six")
+    module.container_abcs = collections.abc
+    module.inf = float("inf")
+    module.nan = float("nan")
+    sys.modules["torch._six"] = module
+
 import timm
 
 assert timm.__version__ == "0.3.2"  # version check
@@ -74,6 +85,11 @@ def get_args_parser():
     # Dataset parameters
     parser.add_argument('--data_path', default='/datasets01/imagenet_full_size/061417/', type=str,
                         help='dataset path')
+    parser.add_argument(
+        '--no_train_dir',
+        action='store_true',
+        help='Do not append /train to data_path (e.g. Hyperkvasir-unlabelled)',
+    )
 
     parser.add_argument('--output_dir', default='./output_dir',
                         help='path where to save, empty for no saving')
@@ -125,7 +141,8 @@ def main(args):
             transforms.RandomHorizontalFlip(),
             transforms.ToTensor(),
             transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])])
-    dataset_train = datasets.ImageFolder(os.path.join(args.data_path, 'train'), transform=transform_train)
+    data_dir = args.data_path if args.no_train_dir else os.path.join(args.data_path, 'train')
+    dataset_train = datasets.ImageFolder(data_dir, transform=transform_train)
     print(dataset_train)
 
     if True:  # args.distributed:

--- a/Models/mae/models_mae.py
+++ b/Models/mae/models_mae.py
@@ -16,7 +16,7 @@ import torch.nn as nn
 
 from timm.models.vision_transformer import PatchEmbed, Block
 
-from .util.pos_embed import get_2d_sincos_pos_embed
+from util.pos_embed import get_2d_sincos_pos_embed
 
 
 class MaskedAutoencoderViT(nn.Module):

--- a/Models/mae/run_hyperkvasir_pretraining.py
+++ b/Models/mae/run_hyperkvasir_pretraining.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Launch MAE pretraining on Hyperkvasir-unlabelled.
+
+This helper wraps ``main_pretrain.py`` with the arguments used in the
+paper to produce SSL-colon weights. It assumes the Hyperkvasir-unlabelled
+frames are laid out as ``<root>/<video_id>/<frame>.jpg``.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from typing import List
+
+
+def run(cmd: List[str]) -> None:
+    """Run a subprocess and stream its output."""
+    print("Running:", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Pretrain ViT-B/16 with MAE on Hyperkvasir-unlabelled"
+    )
+    parser.add_argument(
+        "--data-root",
+        required=True,
+        help="Path to Hyperkvasir-unlabelled dataset root",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory to store checkpoints and logs",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        help="Batch size per GPU",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=400,
+        help="Number of training epochs",
+    )
+    parser.add_argument(
+        "--extra-args",
+        default="",
+        help="Additional arguments forwarded to main_pretrain.py",
+    )
+    args = parser.parse_args()
+
+    script = os.path.join(os.path.dirname(__file__), "main_pretrain.py")
+    cmd = [
+        sys.executable,
+        script,
+        "--model",
+        "mae_vit_base_patch16",
+        "--data_path",
+        args.data_root,
+        "--output_dir",
+        args.output_dir,
+        "--log_dir",
+        args.output_dir,
+        "--batch_size",
+        str(args.batch_size),
+        "--epochs",
+        str(args.epochs),
+        "--no_train_dir",
+    ] + args.extra_args.split()
+    run(cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ Follow the guidance in this section for obtaining the weights for pretrained mod
 
 + For encoders pretrained in a supervised manner with ImageNet-1k, the weights provided with the [timm](https://timm.fast.ai/) library (ViT-B) are automatically used by our code and no manual steps are required.
 + For encoders pretrained in a self-supervised manner with ImageNet-1k, using [MAE](https://github.com/facebookresearch/mae), the weights provided with the codebase should be used.
-+ For encoders pretrained in a self-supervised manner with [Hyperkvasir-unlabelled](https://datasets.simula.no/hyper-kvasir/), using [MAE](https://github.com/facebookresearch/mae), the codebase should be used for pretraining. The code should first be modified to allow pretraining with Hyperkvasir-unabelled (remove `'/train'` from data path) and the guidance in the respective codebase for running the pretraining should then be followed with any arguments adjusted for your given hardware as needed.
++ For encoders pretrained in a self-supervised manner with [Hyperkvasir-unlabelled](https://datasets.simula.no/hyper-kvasir/), using [MAE](https://github.com/facebookresearch/mae), use the helper script `Models/mae/run_hyperkvasir_pretraining.py` to generate the checkpoint. Example:
+
+```bash
+python Models/mae/run_hyperkvasir_pretraining.py \
+    --data-root /path/to/hyperkvasir-unlabelled \
+    --output-dir /path/to/save \
+    --batch-size 64 --epochs 400
+```
+Additional options supported by `main_pretrain.py` may be appended via `--extra-args`.
 
 ### Finetuning
 
@@ -54,6 +62,16 @@ python train_classification.py \
 * Replace `[dataset]` with name of dataset (e.g., `Hyperkvasir_anatomical` or `Hyperkvasir_pathological`).
 * Replace `[data-root]` with path to the chosen dataset.
 * Replace `[batch-size]` with desired batch size.
+
+To run all three pretraining configurations sequentially (SUP-imnet, SSL-imnet and SSL-colon) you may use the helper script:
+```
+python run_all_pretrainings.py \
+    --dataset [dataset] \
+    --data-root [data-root] \
+    --imagenet-mae /path/to/mae_pretrain_vit_base.pth \
+    --hyperkvasir-mae /path/to/hyperkvasir_mae.pth
+```
+Any additional options supported by `train_classification.py` can be appended via `--extra-args`.
 
 For all finetuning runs, the following optional arguments are also available:
 + `--frozen` - to freeze the pretrained encoder and only train the decoder. We did not use this in our experiments.


### PR DESCRIPTION
## Summary
- add Models/mae/run_hyperkvasir_pretraining.py for MAE pretraining on Hyperkvasir
- allow main_pretrain.py to skip /train and run under modern torch
- document the new pretraining helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python Models/mae/run_hyperkvasir_pretraining.py --help`
- `python Models/mae/main_pretrain.py --no_train_dir --data_path /tmp --output_dir /tmp/out --log_dir /tmp/out --epochs 1 --batch_size 1` *(fails: FileNotFoundError as expected without dataset)*


------
https://chatgpt.com/codex/tasks/task_e_68a99f2b9168832ebe2dcd77d5760021