### PR TITLE
docs: highlight helper scripts and credit repository author

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,30 @@
 # SSL4GIE
-Official code repository for: A Study on Self-Supervised Pretraining for Vision Problems in Gastrointestinal Endoscopy
+Official code repository for *Evaluating Domain-Specific Self-Supervised Pre-training for Polyp Detection: A Morphology-Aware and Sample-Efficient Perspective*,
+based on "A Study on Self-Supervised Pretraining for Vision Problems in Gastrointestinal Endoscopy"
 
-Authors: [Edward Sanderson](https://scholar.google.com/citations?user=ea4c7r0AAAAJ&hl=en&oi=ao) and [Bogdan J. Matuszewski](https://scholar.google.co.uk/citations?user=QlUO_oAAAAAJ&hl=en)
+Original authors: [Edward Sanderson](https://scholar.google.com/citations?user=ea4c7r0AAAAJ&hl=en&oi=ao) and [Bogdan J. Matuszewski](https://scholar.google.co.uk/citations?user=QlUO_oAAAAAJ&hl=en)
 
-Links to the paper:
+Repository author: Ivan Rodriguez-Conde, assistant professor at the Department of Computer Science at University of Vigo ([ivarodriguez@uvigo.gal](mailto:ivarodriguez@uvigo.gal))
+
+Links to the original paper:
 + [IEEE Access (open access)](https://ieeexplore.ieee.org/document/10478725)
 + [arXiv](https://arxiv.org/abs/2401.06278)
+
+## New functionality
+
+We include helper scripts that automate common workflows introduced in the
+paper:
+
+- `Models/mae/run_hyperkvasir_pretraining.py` – wraps MAE pretraining on the
+  Hyperkvasir-unlabelled dataset with the settings used in the paper. The
+  script exposes `--batch-size`, `--epochs` and `--extra-args` so you can tweak
+  the training run or forward additional options to `main_pretrain.py`.
+- `Classification/run_all_pretrainings.py` – sequentially fine-tunes ViT-B/16
+  under all three pretraining schemes (SUP-imnet, SSL-imnet and SSL-colon).
+  Customise the architecture and batch size with `--arch` and `--batch-size`,
+  and pass further arguments to `train_classification.py` via `--extra-args`.
+
+The following sections describe how to invoke these utilities.
 
 ## Usage
 
@@ -15,7 +34,12 @@ Follow the guidance in this section for obtaining the weights for pretrained mod
 
 + For encoders pretrained in a supervised manner with ImageNet-1k, the weights provided with the [timm](https://timm.fast.ai/) library (ViT-B) are automatically used by our code and no manual steps are required.
 + For encoders pretrained in a self-supervised manner with ImageNet-1k, using [MAE](https://github.com/facebookresearch/mae), the weights provided with the codebase should be used.
-+ For encoders pretrained in a self-supervised manner with [Hyperkvasir-unlabelled](https://datasets.simula.no/hyper-kvasir/), using [MAE](https://github.com/facebookresearch/mae), use the helper script `Models/mae/run_hyperkvasir_pretraining.py` to generate the checkpoint. Example:
++ For encoders pretrained in a self-supervised manner with
+  [Hyperkvasir-unlabelled](https://datasets.simula.no/hyper-kvasir/), using
+  [MAE](https://github.com/facebookresearch/mae), use the helper script
+  `Models/mae/run_hyperkvasir_pretraining.py` to generate the checkpoint. You can
+  override the default `--batch-size` and `--epochs` values and pass additional
+  options to `main_pretrain.py` via `--extra-args`. Example:
 
 ```bash
 python Models/mae/run_hyperkvasir_pretraining.py \
@@ -23,7 +47,6 @@ python Models/mae/run_hyperkvasir_pretraining.py \
     --output-dir /path/to/save \
     --batch-size 64 --epochs 400
 ```
-Additional options supported by `main_pretrain.py` may be appended via `--extra-args`.
 
 ### Finetuning
 
@@ -71,7 +94,9 @@ python run_all_pretrainings.py \
     --imagenet-mae /path/to/mae_pretrain_vit_base.pth \
     --hyperkvasir-mae /path/to/hyperkvasir_mae.pth
 ```
-Any additional options supported by `train_classification.py` can be appended via `--extra-args`.
+Optionally use `--arch` to choose a backbone (default `vit_b`) and `--batch-size`
+to set the batch size for each run. Any additional options supported by
+`train_classification.py` can be appended via `--extra-args`.
 
 For all finetuning runs, the following optional arguments are also available:
 + `--frozen` - to freeze the pretrained encoder and only train the decoder. We did not use this in our experiments.


### PR DESCRIPTION
## Summary
- document helper scripts `run_hyperkvasir_pretraining.py` and `run_all_pretrainings.py`
- explain optional flags for customizing pretraining and sequential fine-tuning runs
- credit Ivan Rodriguez-Conde as repository author and mention polyp-detection evaluation based on the original paper

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9cbee4a4c832ea1ef12556d0bc0f5