### PR TITLE
feat: support simple classification dataset layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ python train_classification.py \
 * Replace `[data-root]` with path to the chosen dataset.
 * Replace `[batch-size]` with desired batch size.
 
+The script expects the HyperKvasir directory structure by default. For datasets
+organised more simply as `data-root/class_x/*.jpg`, pass `--simple-dataset` and
+lay out the images like:
+
+```
+data-root/
+├─ class_0/
+│   ├─ img001.jpg
+│   └─ ...
+└─ class_1/
+    ├─ img050.jpg
+    └─ ...
+```
+
 To run all three pretraining configurations sequentially (SUP-imnet, SSL-imnet and SSL-colon) you may use the helper script:
 ```
 python run_all_pretrainings.py \


### PR DESCRIPTION
## Summary
- allow training on simple `root/class_x/*.jpg` datasets via `--simple-dataset`
- document flat directory usage in README

## Testing
- `python -m py_compile Classification/train_classification.py`
- `PYTHONPATH=../Models/mae python train_classification.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a9d08d0cc0832e9d04ac1add460716