### PR TITLE
Support simple dataset structure for classification training

### DIFF
--- a/Classification/train_classification.py
+++ b/Classification/train_classification.py
@@ -127,7 +127,10 @@ def test(model, rank, test_loader, epoch, perf_fn, log_path):
 
 def build(args, rank):
 
-    if args.simple:
+    simple_layout = args.simple or not os.path.exists(
+        os.path.join(args.root, "labeled-images")
+    )
+    if simple_layout:
         class_dirs = sorted(glob.glob(os.path.join(args.root, "*/")))
         class_id = 0
         input_paths = []
@@ -392,7 +395,13 @@ def get_args():
         type=str,
         required=True,
     )
-    parser.add_argument("--simple-dataset", action="store_true", default=False, dest="simple")
+    parser.add_argument(
+        "--simple-dataset",
+        action="store_true",
+        default=False,
+        dest="simple",
+        help="assume data_root/class_x/*.jpg structure; inferred if 'labeled-images' missing",
+    )
     parser.add_argument("--data-root", type=str, required=True, dest="root")
     parser.add_argument("--epochs", type=int, default=50)
     parser.add_argument("--batch-size", type=int, default=16)

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ python train_classification.py \
 * Replace `[batch-size]` with desired batch size.
 
 The script expects the HyperKvasir directory structure by default. For datasets
-organised more simply as `data-root/class_x/*.jpg`, pass `--simple-dataset` and
-lay out the images like:
+organised more simply as `data-root/class_x/*.jpg`, either pass `--simple-dataset`
+or point `--data-root` to the top-level directory and the script will infer this
+layout automatically. Arrange images as:
 
 ```
 data-root/


### PR DESCRIPTION
## Summary
- allow `train_classification.py` to auto-detect when `data-root` holds class folders directly
- document simplified dataset layout and optional `--simple-dataset` flag in README

## Testing
- `python -m py_compile Classification/train_classification.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc25f7e974832e98545820b45d5179