### PR TITLE
Expose gradient accumulation in MAE pretraining

### DIFF
--- a/Models/mae/util/misc.py
+++ b/Models/mae/util/misc.py
@@ -254,6 +254,16 @@ class NativeScalerWithGradNormCount:
     def __init__(self):
         self._scaler = torch.cuda.amp.GradScaler()
 
+    # Expose underlying GradScaler methods for explicit gradient accumulation
+    def scale(self, loss):
+        return self._scaler.scale(loss)
+
+    def step(self, optimizer):
+        self._scaler.step(optimizer)
+
+    def update(self):
+        self._scaler.update()
+
     def __call__(self, loss, optimizer, clip_grad=None, parameters=None, create_graph=False, update_grad=True):
         self._scaler.scale(loss).backward(create_graph=create_graph)
         if update_grad:


### PR DESCRIPTION
## Summary
- make gradient accumulation explicit in MAE pretraining
- expose scale/step/update on NativeScaler for manual accumulation control

## Testing
- `python -m py_compile Models/mae/engine_pretrain.py Models/mae/util/misc.py`
- `pip install -r requirements.txt` *(fails: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_68bf03559d68832e84c66aa2a4869557