### PR TITLE
Add configurable DataLoader parameters

### DIFF
--- a/Classification/Data/dataloaders.py
+++ b/Classification/Data/dataloaders.py
@@ -57,7 +57,17 @@ def split_ids(len_ids):
     return train_indices, test_indices, val_indices
 
 
-def get_dataloaders(rank, world_size, input_paths, targets, batch_size):
+def get_dataloaders(
+    rank,
+    world_size,
+    input_paths,
+    targets,
+    batch_size,
+    workers=8,
+    prefetch_factor=2,
+    pin_memory=True,
+    persistent_workers=True,
+):
 
     transform_input4train = transforms.Compose(
         [
@@ -92,7 +102,10 @@ def get_dataloaders(rank, world_size, input_paths, targets, batch_size):
         batch_size=batch_size,
         sampler=train_sampler,
         drop_last=True,
-        num_workers=8,
+        num_workers=workers,
+        prefetch_factor=prefetch_factor,
+        pin_memory=pin_memory,
+        persistent_workers=persistent_workers,
     )
 
     if rank == 0:
@@ -121,11 +134,23 @@ def get_dataloaders(rank, world_size, input_paths, targets, batch_size):
         test_dataset = data.Subset(test_dataset, test_indices)
 
         test_dataloader = MultiEpochsDataLoader(
-            dataset=test_dataset, batch_size=batch_size, shuffle=False, num_workers=8
+            dataset=test_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=workers,
+            prefetch_factor=prefetch_factor,
+            pin_memory=pin_memory,
+            persistent_workers=persistent_workers,
         )
 
         val_dataloader = MultiEpochsDataLoader(
-            dataset=val_dataset, batch_size=batch_size, shuffle=False, num_workers=8
+            dataset=val_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=workers,
+            prefetch_factor=prefetch_factor,
+            pin_memory=pin_memory,
+            persistent_workers=persistent_workers,
         )
     else:
         test_dataloader = None
@@ -134,7 +159,14 @@ def get_dataloaders(rank, world_size, input_paths, targets, batch_size):
     return train_dataloader, test_dataloader, val_dataloader, train_sampler
 
 
-def get_test_dataloader(input_paths, targets):
+def get_test_dataloader(
+    input_paths,
+    targets,
+    workers=8,
+    prefetch_factor=2,
+    pin_memory=True,
+    persistent_workers=True,
+):
 
     _, test_indices, _ = split_ids(len(input_paths))
 
@@ -152,7 +184,13 @@ def get_test_dataloader(input_paths, targets):
     test_dataset = data.Subset(test_dataset, test_indices)
 
     test_dataloader = MultiEpochsDataLoader(
-        dataset=test_dataset, batch_size=1, shuffle=False, num_workers=8
+        dataset=test_dataset,
+        batch_size=1,
+        shuffle=False,
+        num_workers=workers,
+        prefetch_factor=prefetch_factor,
+        pin_memory=pin_memory,
+        persistent_workers=persistent_workers,
     )
 
     return test_dataloader

--- a/Classification/eval_classification.py
+++ b/Classification/eval_classification.py
@@ -93,7 +93,14 @@ def build(args):
         n_class = class_id
         args.n_class = n_class
 
-    test_dataloader = dataloaders.get_test_dataloader(input_paths, targets)
+    test_dataloader = dataloaders.get_test_dataloader(
+        input_paths,
+        targets,
+        workers=args.workers,
+        prefetch_factor=args.prefetch_factor,
+        pin_memory=args.pin_memory,
+        persistent_workers=args.persistent_workers,
+    )
 
     if args.pretraining in ["Hyperkvasir", "ImageNet_self"]:
         model = utils.get_MAE_backbone(None, True, n_class, False, None)
@@ -151,6 +158,10 @@ def get_args():
         choices=["Hyperkvasir_pathological", "Hyperkvasir_anatomical"],
     )
     parser.add_argument("--data-root", type=str, required=True, dest="root")
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument("--prefetch-factor", type=int, default=2)
+    parser.add_argument("--pin-memory", action="store_true", default=True)
+    parser.add_argument("--persistent-workers", action="store_true", default=True)
 
     return parser.parse_args()
 

--- a/Classification/train_classification.py
+++ b/Classification/train_classification.py
@@ -184,8 +184,12 @@ def build(args, rank):
         rank,
         args.world_size,
         input_paths,
-        targets,
+       targets,
         batch_size=args.batch_size // args.world_size,
+        workers=args.workers,
+        prefetch_factor=args.prefetch_factor,
+        pin_memory=args.pin_memory,
+        persistent_workers=args.persistent_workers,
     )
 
     if args.pretraining in ["Hyperkvasir", "ImageNet_self"]:
@@ -411,6 +415,14 @@ def get_args():
     )
     parser.add_argument(
         "--learning-rate-scheduler-minimum", type=float, default=1e-6, dest="lrs_min"
+    )
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument("--prefetch-factor", type=int, default=2)
+    parser.add_argument(
+        "--pin-memory", action="store_true", default=True
+    )
+    parser.add_argument(
+        "--persistent-workers", action="store_true", default=True
     )
 
     return parser.parse_args()


### PR DESCRIPTION
## Summary
- allow configuring DataLoader workers, prefetch factor, pin memory, and persistent workers via CLI
- apply these options when building training and evaluation dataloaders

## Testing
- `python -m py_compile Classification/Data/dataloaders.py Classification/train_classification.py Classification/eval_classification.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf373a5cf4832e9b69e6791cbd0896