### PR TITLE
Add precision flag for optional AMP

### DIFF
--- a/Models/mae/engine_finetune.py
+++ b/Models/mae/engine_finetune.py
@@ -52,7 +52,7 @@ def train_one_epoch(model: torch.nn.Module, criterion: torch.nn.Module,
         if mixup_fn is not None:
             samples, targets = mixup_fn(samples, targets)
 
-        with torch.cuda.amp.autocast():
+        with torch.cuda.amp.autocast(enabled=(args.precision == 'amp')):
             outputs = model(samples)
             loss = criterion(outputs, targets)
 
@@ -96,7 +96,7 @@ def train_one_epoch(model: torch.nn.Module, criterion: torch.nn.Module,
 
 
 @torch.no_grad()
-def evaluate(data_loader, model, device):
+def evaluate(data_loader, model, device, use_amp: bool = True):
     criterion = torch.nn.CrossEntropyLoss()
 
     metric_logger = misc.MetricLogger(delimiter="  ")
@@ -112,7 +112,7 @@ def evaluate(data_loader, model, device):
         target = target.to(device, non_blocking=True)
 
         # compute output
-        with torch.cuda.amp.autocast():
+        with torch.cuda.amp.autocast(enabled=use_amp):
             output = model(images)
             loss = criterion(output, target)
 

--- a/Models/mae/engine_pretrain.py
+++ b/Models/mae/engine_pretrain.py
@@ -44,7 +44,7 @@ def train_one_epoch(model: torch.nn.Module,
 
         samples = samples.to(device, non_blocking=True)
 
-        with torch.cuda.amp.autocast():
+        with torch.cuda.amp.autocast(enabled=(args.precision == 'amp')):
             loss, _, _ = model(samples, mask_ratio=args.mask_ratio)
 
         loss_value = loss.item()

--- a/Models/mae/main_linprobe.py
+++ b/Models/mae/main_linprobe.py
@@ -109,6 +109,7 @@ def get_args_parser():
     parser.add_argument('--dist_on_itp', action='store_true')
     parser.add_argument('--dist_url', default='env://',
                         help='url used to set up distributed training')
+    parser.add_argument('--precision', choices=['amp', 'fp32'], default='amp')
 
     return parser
 
@@ -127,6 +128,7 @@ def main(args):
     np.random.seed(seed)
 
     cudnn.benchmark = True
+    use_amp = args.precision == 'amp'
 
     # linear probe: weak augmentation
     transform_train = transforms.Compose([
@@ -251,7 +253,7 @@ def main(args):
 
     optimizer = LARS(model_without_ddp.head.parameters(), lr=args.lr, weight_decay=args.weight_decay)
     print(optimizer)
-    loss_scaler = NativeScaler()
+    loss_scaler = NativeScaler(enabled=use_amp)
 
     criterion = torch.nn.CrossEntropyLoss()
 
@@ -260,7 +262,7 @@ def main(args):
     misc.load_model(args=args, model_without_ddp=model_without_ddp, optimizer=optimizer, loss_scaler=loss_scaler)
 
     if args.eval:
-        test_stats = evaluate(data_loader_val, model, device)
+        test_stats = evaluate(data_loader_val, model, device, use_amp=use_amp)
         print(f"Accuracy of the network on the {len(dataset_val)} test images: {test_stats['acc1']:.1f}%")
         exit(0)
 
@@ -282,7 +284,7 @@ def main(args):
                 args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
                 loss_scaler=loss_scaler, epoch=epoch)
 
-        test_stats = evaluate(data_loader_val, model, device)
+        test_stats = evaluate(data_loader_val, model, device, use_amp=use_amp)
         print(f"Accuracy of the network on the {len(dataset_val)} test images: {test_stats['acc1']:.1f}%")
         max_accuracy = max(max_accuracy, test_stats["acc1"])
         print(f'Max accuracy: {max_accuracy:.2f}%')

--- a/Models/mae/main_pretrain.py
+++ b/Models/mae/main_pretrain.py
@@ -127,6 +127,7 @@ def get_args_parser():
     parser.add_argument('--dist_on_itp', action='store_true')
     parser.add_argument('--dist_url', default='env://',
                         help='url used to set up distributed training')
+    parser.add_argument('--precision', choices=['amp', 'fp32'], default='amp')
 
     return parser
 
@@ -207,7 +208,7 @@ def main(args):
     param_groups = optim_factory.add_weight_decay(model_without_ddp, args.weight_decay)
     optimizer = torch.optim.AdamW(param_groups, lr=args.lr, betas=(0.9, 0.95))
     print(optimizer)
-    loss_scaler = NativeScaler()
+    loss_scaler = NativeScaler(enabled=(args.precision == 'amp'))
 
     misc.load_model(args=args, model_without_ddp=model_without_ddp, optimizer=optimizer, loss_scaler=loss_scaler)
 

--- a/Models/mae/util/misc.py
+++ b/Models/mae/util/misc.py
@@ -251,8 +251,8 @@ def init_distributed_mode(args):
 class NativeScalerWithGradNormCount:
     state_dict_key = "amp_scaler"
 
-    def __init__(self):
-        self._scaler = torch.cuda.amp.GradScaler()
+    def __init__(self, enabled: bool = True):
+        self._scaler = torch.cuda.amp.GradScaler(enabled=enabled)
 
     # Expose underlying GradScaler methods for explicit gradient accumulation
     def scale(self, loss):


### PR DESCRIPTION
## Summary
- Add `--precision` option to classification and MAE training scripts
- Toggle GradScaler and autocast based on the chosen precision
- Allow NativeScaler to disable mixed precision when using fp32

## Testing
- `python -m py_compile Classification/train_classification.py Models/mae/util/misc.py Models/mae/engine_pretrain.py Models/mae/engine_finetune.py Models/mae/main_pretrain.py Models/mae/main_finetune.py Models/mae/main_linprobe.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf3819bfc0832ebedd997de85b13e7