### PR TITLE
Add --acum_iter alias to MAE scripts

### DIFF
--- a/Models/mae/main_finetune.py
+++ b/Models/mae/main_finetune.py
@@ -44,7 +44,7 @@ def get_args_parser():
     parser.add_argument('--batch_size', default=64, type=int,
                         help='Batch size per GPU (effective batch size is batch_size * accum_iter * # gpus')
     parser.add_argument('--epochs', default=50, type=int)
-    parser.add_argument('--accum_iter', default=1, type=int,
+    parser.add_argument('--accum_iter', '--acum_iter', dest='accum_iter', default=1, type=int,
                         help='Accumulate gradient iterations (for increasing the effective batch size under memory constraints)')
 
     # Model parameters

--- a/Models/mae/main_linprobe.py
+++ b/Models/mae/main_linprobe.py
@@ -44,7 +44,7 @@ def get_args_parser():
     parser.add_argument('--batch_size', default=512, type=int,
                         help='Batch size per GPU (effective batch size is batch_size * accum_iter * # gpus')
     parser.add_argument('--epochs', default=90, type=int)
-    parser.add_argument('--accum_iter', default=1, type=int,
+    parser.add_argument('--accum_iter', '--acum_iter', dest='accum_iter', default=1, type=int,
                         help='Accumulate gradient iterations (for increasing the effective batch size under memory constraints)')
 
     # Model parameters

--- a/Models/mae/main_pretrain.py
+++ b/Models/mae/main_pretrain.py
@@ -55,7 +55,7 @@ def get_args_parser():
     parser.add_argument('--batch_size', default=64, type=int,
                         help='Batch size per GPU (effective batch size is batch_size * accum_iter * # gpus')
     parser.add_argument('--epochs', default=400, type=int)
-    parser.add_argument('--accum_iter', default=1, type=int,
+    parser.add_argument('--accum_iter', '--acum_iter', dest='accum_iter', default=1, type=int,
                         help='Accumulate gradient iterations (for increasing the effective batch size under memory constraints)')
 
     # Model parameters


### PR DESCRIPTION
## Summary
- allow `--acum_iter` as alias for `--accum_iter` across MAE pretrain/finetune/linprobe scripts

## Testing
- `python - <<'PY'
import argparse, ast
from pathlib import Path
for file in ['Models/mae/main_pretrain.py','Models/mae/main_finetune.py','Models/mae/main_linprobe.py']:
    src = Path(file).read_text(); mod = ast.parse(src)
    func = next(n for n in mod.body if isinstance(n, ast.FunctionDef) and n.name=='get_args_parser')
    func_src = ast.get_source_segment(src, func); ns = {}
    exec(func_src, {'argparse': argparse}, ns)
    parser = ns['get_args_parser'](); args = parser.parse_args(['--acum_iter','8'])
    assert args.accum_iter == 8
print('parsed successfully')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bff18b4e9c832eb035f96ab0db60e0