### PR TITLE
Add experiment runner script and roots support

### DIFF
--- a/Classification/train_classification.py
+++ b/Classification/train_classification.py
@@ -8,6 +8,7 @@ import random
 import subprocess
 from pathlib import Path
 import warnings
+import json
 
 import yaml
 
@@ -569,6 +570,12 @@ def get_args():
         "--manifest", type=str, dest="manifest_yaml", help="YAML manifest describing dataset pack"
     )
     parser.add_argument(
+        "--roots",
+        type=str,
+        default=None,
+        help="JSON file mapping manifest root identifiers to directories",
+    )
+    parser.add_argument(
         "--class-weights",
         type=str,
         default=None,
@@ -601,6 +608,10 @@ def get_args():
 
 def main():
     args = get_args()
+    roots_map = None
+    if args.roots:
+        with open(args.roots) as f:
+            roots_map = json.load(f)
     manifest_style = any(
         [args.train_csv, args.val_csv, args.test_csv, args.manifest_yaml]
     )
@@ -622,6 +633,8 @@ def main():
             manifest_yaml=Path(args.manifest_yaml)
             if args.manifest_yaml
             else None,
+            roots_map=roots_map,
+            snapshot_dir=Path(args.output_dir),
         )
         (
             args.train_paths,

--- a/scripts/run_exps.sh
+++ b/scripts/run_exps.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run experiments Exp-1..Exp-5 using manifests and a roots mapping.
+# Usage: scripts/run_exps.sh MANIFEST_DIR ROOTS_JSON OUT_BASE
+# MANIFEST_DIR: Directory containing manifest YAML files exp1.yaml..exp5.yaml
+# ROOTS_JSON: JSON file mapping root identifiers to filesystem paths
+# OUT_BASE: Base directory for experiment outputs
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 MANIFEST_DIR ROOTS_JSON OUT_BASE" >&2
+  exit 1
+fi
+
+MANIFEST_DIR="$1"
+ROOTS_JSON="$2"
+OUT_BASE="$3"
+
+CSV="joblist.csv"
+# Initialize joblist.csv with header if it doesn't exist
+if [[ ! -f "$CSV" ]]; then
+  echo "exp,manifest,output_dir" > "$CSV"
+fi
+
+for EXP in 1 2 3 4 5; do
+  MANIFEST_PATH="${MANIFEST_DIR}/exp${EXP}.yaml"
+  OUT_DIR="${OUT_BASE}/exp${EXP}"
+
+  echo "${EXP},${MANIFEST_PATH},${OUT_DIR}" >> "$CSV"
+
+  python Classification/train_classification.py \
+    --manifest "$MANIFEST_PATH" \
+    --roots "$ROOTS_JSON" \
+    --output-dir "$OUT_DIR"
+done


### PR DESCRIPTION
## Summary
- add `scripts/run_exps.sh` to run Exp-1..5, update `joblist.csv`, and launch the trainer
- allow `train_classification.py` to accept a `--roots` JSON mapping for manifest datasets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3bede82ec832eaf04f46f28e274e0