### PR TITLE
Add default artifact directories and update defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,24 @@
+# Experiment artefacts (allow documentation of layout)
 /checkpoints/*
+!/checkpoints/.gitignore
+!/checkpoints/README.md
+
+/data/*
+!/data/.gitignore
+!/data/README.md
+!/data/roots.example.json
+
+/outputs/*
+!/outputs/.gitignore
+!/outputs/README.md
+
+/results/*
+!/results/.gitignore
+!/results/README.md
+
+# Python cache and virtual environment files
+__pycache__/
+*.py[cod]
+*$py.class
+.venv/
+.env/

--- a/checkpoints/.gitignore
+++ b/checkpoints/.gitignore
@@ -1,0 +1,4 @@
+# Ignore generated checkpoints and logs.
+*
+!/README.md
+!/.gitignore

--- a/checkpoints/README.md
+++ b/checkpoints/README.md
@@ -1,0 +1,19 @@
+# Checkpoints directory
+
+Use this folder as the default location for trained model weights and
+snapshots produced by experiments. Suggested structure:
+
+```
+checkpoints/
+├─ classification/
+│  ├─ exp01/
+│  │  ├─ best.pth
+│  │  └─ tb/
+│  └─ ...
+└─ mae/
+   ├─ pretrain/
+   └─ finetune/
+```
+
+Training scripts default to saving outputs here but accept command-line flags
+to override the destination if you prefer a custom layout.

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,5 @@
+# Ignore local datasets and manifest roots.
+*
+!/README.md
+!/.gitignore
+!/roots.example.json

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,22 @@
+# Data directory
+
+Store raw datasets, extracted frames, and manifest resources in this folder.
+The repository keeps the directory structure under version control while
+ignoring the actual data.
+
+A recommended layout is:
+
+```
+data/
+├─ roots.json              # maps manifest root identifiers to absolute paths
+├─ roots.example.json      # sample template provided by the repo
+├─ hyperkvasir/
+│  ├─ train/
+│  ├─ val/
+│  └─ test/
+└─ additional_dataset/
+   └─ ...
+```
+
+Copy `roots.example.json` to `roots.json` and edit the paths to point to your
+local storage before launching experiments.

--- a/data/roots.example.json
+++ b/data/roots.example.json
@@ -1,0 +1,3 @@
+{
+  "data_root": "/absolute/path/to/datasets/hyperkvasir"
+}

--- a/outputs/.gitignore
+++ b/outputs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore experiment logs and intermediate artefacts.
+*
+!/README.md
+!/.gitignore

--- a/outputs/README.md
+++ b/outputs/README.md
@@ -1,0 +1,18 @@
+# Outputs directory
+
+Store experiment metadata, TensorBoard runs, predictions and other
+intermediate artefacts that you want to keep separate from reusable
+checkpoints. For example:
+
+```
+outputs/
+├─ exp01/
+│  ├─ tb/
+│  ├─ predictions.csv
+│  └─ notes.md
+└─ mae/
+   └─ pretrain_logs/
+```
+
+Feel free to reorganise or override destinations via command-line flags when
+running the provided scripts.

--- a/results/.gitignore
+++ b/results/.gitignore
@@ -1,0 +1,4 @@
+# Ignore evaluation exports and analysis artefacts.
+*
+!/README.md
+!/.gitignore

--- a/results/README.md
+++ b/results/README.md
@@ -1,0 +1,18 @@
+# Results directory
+
+Collect evaluation exports, tables and figures in this folder so they remain
+separate from raw experiment logs and checkpoints. A simple structure could
+look like:
+
+```
+results/
+├─ classification/
+│  ├─ exp01_metrics.csv
+│  └─ confusion_matrix.png
+└─ mae/
+   └─ linprobe/
+      └─ summary.json
+```
+
+Commands that emit reports default to writing here but can be overridden on the
+command line when required.

--- a/scripts/run_exps.sh
+++ b/scripts/run_exps.sh
@@ -6,15 +6,20 @@ from ssl4polyp.configs import config_root
 print(config_root())
 PY
 )
+REPO_ROOT=$(dirname "$CONFIG_ROOT")
+DEFAULT_ROOTS_JSON="${REPO_ROOT}/data/roots.json"
+DEFAULT_OUT_BASE="${REPO_ROOT}/checkpoints/classification"
 
 # Run experiments Exp-1..Exp-5 using manifests and a roots mapping.
-# Usage: scripts/run_exps.sh MANIFEST_DIR ROOTS_JSON OUT_BASE
+# Usage: scripts/run_exps.sh MANIFEST_DIR [ROOTS_JSON] [OUT_BASE]
 # MANIFEST_DIR: Directory containing manifest YAML files exp1.yaml..exp5.yaml
 # ROOTS_JSON: JSON file mapping root identifiers to filesystem paths
+#             (default: data/roots.json)
 # OUT_BASE: Base directory for experiment outputs
+#           (default: checkpoints/classification)
 
-if [[ $# -ne 3 ]]; then
-  echo "Usage: $0 MANIFEST_DIR ROOTS_JSON OUT_BASE" >&2
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+  echo "Usage: $0 MANIFEST_DIR [ROOTS_JSON] [OUT_BASE]" >&2
   exit 1
 fi
 
@@ -22,11 +27,11 @@ MANIFEST_DIR="$1"
 if [[ "$MANIFEST_DIR" != /* && ! -e "$MANIFEST_DIR" ]]; then
   MANIFEST_DIR="${CONFIG_ROOT}/${MANIFEST_DIR}"
 fi
-ROOTS_JSON="$2"
+ROOTS_JSON="${2:-$DEFAULT_ROOTS_JSON}"
 if [[ "$ROOTS_JSON" != /* && ! -e "$ROOTS_JSON" ]]; then
   ROOTS_JSON="${CONFIG_ROOT}/${ROOTS_JSON}"
 fi
-OUT_BASE="$3"
+OUT_BASE="${3:-$DEFAULT_OUT_BASE}"
 
 CSV="joblist.csv"
 # Initialize joblist.csv with header if it doesn't exist

--- a/src/ssl4polyp/classification/run_all_pretrainings.py
+++ b/src/ssl4polyp/classification/run_all_pretrainings.py
@@ -10,7 +10,7 @@ three pretraining modes used in the paper:
 
 Checkpoints for the self-supervised options must be supplied via the
 command line. Fine-tuned models are stored in
-``Trained models/`` as usual.
+``checkpoints/`` by default.
 """
 
 import argparse

--- a/src/ssl4polyp/models/mae/main_finetune.py
+++ b/src/ssl4polyp/models/mae/main_finetune.py
@@ -122,10 +122,16 @@ def get_args_parser():
     parser.add_argument('--nb_classes', default=1000, type=int,
                         help='number of the classification types')
 
-    parser.add_argument('--output_dir', default='out',
-                        help='path where to save, empty for no saving')
-    parser.add_argument('--log_dir', default='out/tb',
-                        help='path where to tensorboard log')
+    parser.add_argument(
+        '--output_dir',
+        default=str(Path('checkpoints') / 'mae' / 'finetune'),
+        help='path where to save, empty for no saving'
+    )
+    parser.add_argument(
+        '--log_dir',
+        default=str(Path('outputs') / 'mae' / 'finetune'),
+        help='path where to tensorboard log'
+    )
     parser.add_argument('--device', default='cuda',
                         help='device to use for training / testing')
     parser.add_argument('--seed', default=0, type=int)

--- a/src/ssl4polyp/models/mae/main_linprobe.py
+++ b/src/ssl4polyp/models/mae/main_linprobe.py
@@ -80,10 +80,16 @@ def get_args_parser():
     parser.add_argument('--nb_classes', default=1000, type=int,
                         help='number of the classification types')
 
-    parser.add_argument('--output_dir', default='out',
-                        help='path where to save, empty for no saving')
-    parser.add_argument('--log_dir', default='out/tb',
-                        help='path where to tensorboard log')
+    parser.add_argument(
+        '--output_dir',
+        default=str(Path('results') / 'mae' / 'linprobe'),
+        help='path where to save, empty for no saving'
+    )
+    parser.add_argument(
+        '--log_dir',
+        default=str(Path('outputs') / 'mae' / 'linprobe'),
+        help='path where to tensorboard log'
+    )
     parser.add_argument('--device', default='cuda',
                         help='device to use for training / testing')
     parser.add_argument('--seed', default=0, type=int)

--- a/src/ssl4polyp/models/mae/main_pretrain.py
+++ b/src/ssl4polyp/models/mae/main_pretrain.py
@@ -95,10 +95,16 @@ def get_args_parser():
         help='Do not append /train to data_path (e.g. Hyperkvasir-unlabelled)',
     )
 
-    parser.add_argument('--output_dir', default='out',
-                        help='path where to save, empty for no saving')
-    parser.add_argument('--log_dir', default='out/tb',
-                        help='path where to tensorboard log')
+    parser.add_argument(
+        '--output_dir',
+        default=str(Path('checkpoints') / 'mae' / 'pretrain'),
+        help='path where to save, empty for no saving'
+    )
+    parser.add_argument(
+        '--log_dir',
+        default=str(Path('outputs') / 'mae' / 'pretrain'),
+        help='path where to tensorboard log'
+    )
     parser.add_argument('--device', default='cuda',
                         help='device to use for training / testing')
     parser.add_argument('--seed', default=0, type=int)

--- a/src/ssl4polyp/models/mae/run_hyperkvasir_pretraining.py
+++ b/src/ssl4polyp/models/mae/run_hyperkvasir_pretraining.py
@@ -37,8 +37,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--output-dir",
-        required=True,
-        help="Directory to store checkpoints and logs",
+        default=os.path.join("checkpoints", "mae", "hyperkvasir_pretrain"),
+        help="Directory to store checkpoints",
     )
     parser.add_argument(
         "--batch-size",
@@ -56,6 +56,11 @@ def main() -> None:
         "--extra-args",
         default="",
         help="Additional arguments forwarded to main_pretrain.py",
+    )
+    parser.add_argument(
+        "--log-dir",
+        default=os.path.join("outputs", "mae", "hyperkvasir_pretrain"),
+        help="Directory to store TensorBoard logs",
     )
     parser.add_argument(
         "--auto-resume",
@@ -98,7 +103,7 @@ def main() -> None:
         "--output_dir",
         args.output_dir,
         "--log_dir",
-        os.path.join(args.output_dir, "tb"),
+        os.path.join(args.log_dir, "tb"),
         "--batch_size",
         str(args.batch_size),
         "--epochs",

--- a/src/ssl4polyp/polypdb/cli.py
+++ b/src/ssl4polyp/polypdb/cli.py
@@ -30,8 +30,18 @@ def main(argv: list[str] | None = None) -> None:
     corrupt_parser = sun_sub.add_parser("corrupt")
     corrupt_parser.add_argument("--pack", type=Path, required=True)
     corrupt_parser.add_argument("--spec", type=Path, required=True)
-    corrupt_parser.add_argument("--roots", type=Path, required=True)
-    corrupt_parser.add_argument("--out", type=Path, required=True)
+    corrupt_parser.add_argument(
+        "--roots",
+        type=Path,
+        default=Path("data") / "roots.json",
+        help="JSON mapping of dataset roots (default: data/roots.json)",
+    )
+    corrupt_parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("results") / "polypdb" / "sun_corruptions",
+        help="Directory to export corrupted packs (default: results/polypdb/sun_corruptions)",
+    )
 
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
## Summary
- add git-ignored data, checkpoints, outputs, and results directories with guidance for consistent layouts
- point training, evaluation, and preprocessing scripts at the new default directories while keeping overrides available
- document the standard artifact locations and refreshed command defaults in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cbd8c5aec4832e9cf50825dd1b4170