### PR TITLE
Switch classification validation metric to AUROC

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -8,7 +8,7 @@ scheduler:
   name: cosine
   warmup_epochs: 5
 early_stop:
-  monitor: val_f1
+  monitor: val_auroc
   patience: 10
 threshold_policy: youden
 seed: 47


### PR DESCRIPTION
## Summary
- update classification training to measure validation/test performance with mean AUROC using logits and report auxiliary metrics
- log validation and test AUROC/F1/precision/recall to TensorBoard and checkpoints while keeping helper able to return logits
- default early stopping monitor to `val_auroc` in both CLI arguments and base config

## Testing
- python -m compileall src/ssl4polyp/classification/train_classification.py

------
https://chatgpt.com/codex/tasks/task_e_68cbff3aa634832ea247bee52e3bd1f7