### PR TITLE
Refine threshold handling and defaults

### DIFF
--- a/src/ssl4polyp/classification/eval_classification.py
+++ b/src/ssl4polyp/classification/eval_classification.py
@@ -4,17 +4,26 @@ import csv
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import Optional, Tuple
 
 import torch
 
 from ssl4polyp import utils
 from ssl4polyp.classification.data import create_classification_dataloaders
-from ssl4polyp.classification.metrics import performance
+from ssl4polyp.classification.metrics import performance, thresholds as threshold_utils
 from ssl4polyp.configs import data_packs_root
 
 
 @torch.no_grad()
-def test(model, device, test_loader, args, save_preds=None):
+def test(
+    model,
+    device,
+    test_loader,
+    args,
+    save_preds: Optional[Path] = None,
+    tau: Optional[float] = None,
+    tau_source: Optional[str] = None,
+):
     model.eval()
     mf1 = performance.meanF1Score(n_class=args.n_class)
     mprec = performance.meanPrecision(n_class=args.n_class)
@@ -22,6 +31,8 @@ def test(model, device, test_loader, args, save_preds=None):
     mauroc = performance.meanAUROC(n_class=args.n_class)
     frame_ids = []
     preds_list = []
+    apply_tau = tau is not None and args.n_class == 2
+    warned_tau = False
     for i, batch in enumerate(test_loader):
         if len(batch) != 3:
             raise ValueError("Expected batches to provide (images, labels, metadata)")
@@ -31,7 +42,13 @@ def test(model, device, test_loader, args, save_preds=None):
         target = target.to(device)
         output = model(data)
         probs = torch.softmax(output, dim=1)
-        pred_batch = torch.argmax(output, 1)
+        if tau is not None and args.n_class != 2 and not warned_tau:
+            print("Warning: provided tau but dataset is not binary; ignoring threshold.")
+            warned_tau = True
+        if apply_tau:
+            pred_batch = (probs[:, 1] >= tau).long()
+        else:
+            pred_batch = torch.argmax(probs, 1)
         preds_list.extend(pred_batch.cpu().tolist())
         if i == 0:
             pred = pred_batch
@@ -43,7 +60,9 @@ def test(model, device, test_loader, args, save_preds=None):
             targ = torch.cat((targ, target), 0)
 
     if save_preds is not None and frame_ids:
-        with open(save_preds, "w", newline="") as f:
+        save_path = Path(save_preds)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        with save_path.open("w", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(["frame_id", "prediction"])
             for fid, p in zip(frame_ids, preds_list):
@@ -72,6 +91,10 @@ def test(model, device, test_loader, args, save_preds=None):
         print(print_mrec)
         print(print_mauroc)
         print(print_acc)
+        if tau is not None and args.n_class == 2:
+            tau_label = tau_source or "tau"
+            print_tau = f"{tau_label}: {tau:.6f}"
+            print(print_tau)
         results_path = Path(args.results_file)
         results_path.parent.mkdir(parents=True, exist_ok=True)
         with open(results_path, "a") as f:
@@ -81,6 +104,16 @@ def test(model, device, test_loader, args, save_preds=None):
             f.write(print_mrec + "\n")
             f.write(print_mauroc + "\n")
             f.write(print_acc + "\n")
+            if tau is not None and args.n_class == 2:
+                f.write(f"{tau_label}: {tau:.6f}\n")
+
+    if tau is not None:
+        return {
+            "tau": tau,
+            "tau_source": tau_source,
+        }
+
+    return {}
 
 
 def build(args):
@@ -96,8 +129,10 @@ def build(args):
 
     loaders, datasets, _ = create_classification_dataloaders(
         train_spec=None,
-        val_spec=None,
+        val_spec=args.threshold_pack,
         test_spec=args.test_pack,
+        train_split="train",
+        val_split=args.threshold_split,
         test_split=args.test_split,
         batch_size=args.batch_size,
         num_workers=args.workers,
@@ -119,6 +154,8 @@ def build(args):
     if dataset is None or dataset.labels_list is None:
         raise ValueError("Selected test pack does not provide labels; cannot compute metrics.")
     args.n_class = len(set(dataset.labels_list))
+
+    threshold_loader = loaders.get("val") if args.threshold_pack else None
 
     if args.pretraining in ["Hyperkvasir", "ImageNet_self"]:
         model = utils.get_MAE_backbone(None, True, args.n_class, False, None)
@@ -154,14 +191,90 @@ def build(args):
     model.load_state_dict(checkpoint["model_state_dict"])
     model.to(device)
 
-    return test_dataloader, model, device
+    thresholds_map = dict(checkpoint.get("thresholds", {}) or {})
+    tau_json = ckpt_path.with_suffix(".thresholds.json")
+    if tau_json.exists():
+        try:
+            thresholds_map.update(threshold_utils.load_thresholds(tau_json))
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"Warning: failed to load thresholds from {tau_json}: {exc}")
+
+    return test_dataloader, threshold_loader, model, device, thresholds_map, ckpt_path
+
+
+def _resolve_tau(
+    args,
+    model: torch.nn.Module,
+    device: torch.device,
+    threshold_loader,
+    thresholds_map,
+) -> Tuple[Optional[float], Optional[str]]:
+    raw_policy = (args.threshold_policy or "auto").strip().lower()
+    if raw_policy not in {"auto", "youden", "none"}:
+        raise ValueError(
+            f"Unsupported threshold policy '{raw_policy}'. Use 'auto', 'youden' or 'none'."
+        )
+    policy = raw_policy
+    if policy == "auto":
+        policy = "youden" if args.n_class == 2 else "none"
+        if policy == "none" and args.threshold_pack:
+            print(
+                "Warning: threshold policy resolved to 'none'; ignoring provided threshold pack."
+            )
+    if policy == "none":
+        args.threshold_policy = policy
+        return None, None
+
+    tau: Optional[float] = None
+    tau_source: Optional[str] = None
+    if args.threshold_pack:
+        if threshold_loader is None:
+            raise RuntimeError(
+                "Threshold pack specified but validation loader could not be constructed"
+            )
+        tau = threshold_utils.compute_threshold_from_loader(
+            model, threshold_loader, device, policy=policy
+        )
+        tau_source = f"refit:{args.threshold_pack}:{args.threshold_split}:{policy}"
+    else:
+        threshold_dataset = args.threshold_dataset or args.dataset
+        key = args.threshold_key
+        if key is None and threshold_dataset:
+            key = threshold_utils.format_threshold_key(
+                threshold_dataset, args.threshold_split, policy
+            )
+        tau = threshold_utils.resolve_threshold(thresholds_map, key)
+        if tau is not None:
+            tau_source = key
+        elif key is not None:
+            print(
+                f"Warning: threshold '{key}' not found in checkpoint; proceeding with argmax predictions."
+            )
+    args.threshold_policy = policy
+    return tau, tau_source
 
 
 def evaluate(args):
     args.perturbation_splits = [s.lower() for s in (args.perturbation_splits or [])]
-    test_dataloader, model, device = build(args)
+    (
+        test_dataloader,
+        threshold_loader,
+        model,
+        device,
+        thresholds_map,
+        _,
+    ) = build(args)
+    tau, tau_source = _resolve_tau(args, model, device, threshold_loader, thresholds_map)
     Path(args.results_file).parent.mkdir(parents=True, exist_ok=True)
-    test(model, device, test_dataloader, args, save_preds=args.predictions)
+    test(
+        model,
+        device,
+        test_dataloader,
+        args,
+        save_preds=args.predictions,
+        tau=tau,
+        tau_source=tau_source,
+    )
 
 
 def get_args():
@@ -185,6 +298,37 @@ def get_args():
     parser.add_argument("--dataset", type=str, required=True)
     parser.add_argument("--test-pack", type=str, required=True)
     parser.add_argument("--test-split", type=str, default="test")
+    parser.add_argument(
+        "--threshold-dataset",
+        type=str,
+        default=None,
+        help="Dataset name associated with stored thresholds (defaults to --dataset)",
+    )
+    parser.add_argument(
+        "--threshold-pack",
+        type=str,
+        default=None,
+        help="Pack specification used to re-fit the decision threshold",
+    )
+    parser.add_argument(
+        "--threshold-split",
+        type=str,
+        default="val",
+        help="Split name associated with the threshold (lookup or re-fit)",
+    )
+    parser.add_argument(
+        "--threshold-policy",
+        type=str,
+        default="auto",
+        choices=["auto", "youden", "none"],
+        help="Threshold policy to apply when converting probabilities to labels",
+    )
+    parser.add_argument(
+        "--threshold-key",
+        type=str,
+        default=None,
+        help="Explicit key to load from the checkpoint threshold mapping",
+    )
     parser.add_argument(
         "--pack-root",
         type=str,

--- a/src/ssl4polyp/classification/metrics/__init__.py
+++ b/src/ssl4polyp/classification/metrics/__init__.py
@@ -1,1 +1,8 @@
-"""Metrics for evaluating classification models."""
+"""Metrics and threshold utilities for evaluating classification models."""
+
+from . import performance, thresholds
+
+__all__ = [
+    "performance",
+    "thresholds",
+]

--- a/src/ssl4polyp/classification/metrics/thresholds.py
+++ b/src/ssl4polyp/classification/metrics/thresholds.py
@@ -1,0 +1,167 @@
+"""Threshold utilities for binary classification models.
+
+This module centralises helper functions used to derive decision thresholds
+from validation logits and to persist/retrieve them alongside checkpoints.
+Currently only the Youden's J statistic is implemented which is the policy
+used across the classification experiments.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Mapping, Optional
+
+import numpy as np
+import torch
+from sklearn.metrics import roc_curve
+
+
+ThresholdMap = Dict[str, float]
+
+
+def _prepare_binary_scores(logits: torch.Tensor) -> torch.Tensor:
+    """Normalise ``logits`` into positive-class scores for binary problems."""
+
+    if logits.ndim == 1:
+        return torch.sigmoid(logits)
+    if logits.ndim != 2:
+        raise ValueError(
+            "Binary threshold computation expects logits with shape (N,) or (N, 2)"
+        )
+    if logits.size(1) == 1:
+        return torch.sigmoid(logits.squeeze(1))
+    if logits.size(1) == 2:
+        return torch.softmax(logits, dim=1)[:, 1]
+    raise ValueError(
+        "Binary threshold computation received logits with more than two classes"
+    )
+
+
+def compute_youden_j_threshold(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+) -> float:
+    """Return the threshold maximising Youden's J statistic.
+
+    Parameters
+    ----------
+    logits:
+        Logits produced by a binary classifier. Accepted shapes are ``(N,)``,
+        ``(N, 1)`` or ``(N, 2)``. The function converts them to probabilities
+        for the positive class.
+    targets:
+        Integer tensor containing the binary labels for the associated logits.
+
+    Returns
+    -------
+    float
+        Threshold on the positive-class probability that maximises
+        ``Youden's J = sensitivity + specificity - 1``.
+    """
+
+    if logits.numel() == 0:
+        raise ValueError("Cannot compute threshold on empty logits tensor")
+
+    scores = _prepare_binary_scores(logits).detach().cpu().numpy().astype(float)
+    labels = targets.detach().cpu().numpy().astype(int)
+
+    if scores.shape[0] != labels.shape[0]:
+        raise ValueError("Logits and targets must have matching first dimension")
+    if np.unique(labels).size < 2:
+        raise ValueError("Youden's J threshold requires both positive and negative samples")
+
+    fpr, tpr, thresholds = roc_curve(labels, scores)
+    j_scores = tpr - fpr
+    best_idx = int(np.argmax(j_scores))
+    tau = float(thresholds[best_idx])
+    if np.isinf(tau):
+        # ``roc_curve`` may return ``inf`` when predictions are perfect. In this
+        # case pick a value marginally above the maximum score which effectively
+        # classifies positives perfectly while keeping negatives untouched.
+        tau = float(np.nextafter(scores.max(), 1.0))
+    return tau
+
+
+def format_threshold_key(dataset: str, split: str, policy: str) -> str:
+    """Create a canonical key name for persisted thresholds."""
+
+    return f"{dataset.lower()}_{split.lower()}_{policy.lower()}"
+
+
+def save_thresholds(path: Path, thresholds: Mapping[str, float]) -> None:
+    """Persist ``thresholds`` to ``path`` as a small JSON document."""
+
+    serialisable = {key: float(value) for key, value in thresholds.items()}
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump({"thresholds": serialisable}, handle, indent=2)
+
+
+def load_thresholds(path: Path) -> ThresholdMap:
+    """Load a thresholds mapping previously written by :func:`save_thresholds`."""
+
+    path = Path(path)
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle) or {}
+    raw = payload.get("thresholds", payload)
+    result: ThresholdMap = {}
+    for key, value in raw.items():
+        try:
+            result[key] = float(value)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Invalid threshold value for key {key!r}: {value!r}") from exc
+    return result
+
+
+def resolve_threshold(
+    thresholds: Mapping[str, float],
+    key: Optional[str],
+) -> Optional[float]:
+    """Return the threshold value for ``key`` if present."""
+
+    if key is None:
+        return None
+    if key not in thresholds:
+        return None
+    return float(thresholds[key])
+
+
+def compute_threshold_from_loader(
+    model: torch.nn.Module,
+    loader: torch.utils.data.DataLoader,
+    device: torch.device,
+    *,
+    policy: str = "youden",
+) -> float:
+    """Compute a threshold following ``policy`` using ``loader`` for logits."""
+
+    policy = policy.lower()
+    if policy != "youden":
+        raise ValueError(f"Unsupported threshold policy '{policy}'")
+
+    was_training = model.training
+    model.eval()
+    logits_list: list[torch.Tensor] = []
+    targets_list: list[torch.Tensor] = []
+    with torch.no_grad():
+        for batch in loader:
+            if len(batch) != 3:
+                raise ValueError(
+                    "Threshold computation expects batches with (images, labels, metadata)"
+                )
+            images, labels, _ = batch
+            images = images.to(device)
+            labels = labels.to(device)
+            outputs = model(images).detach().cpu()
+            logits_list.append(outputs)
+            targets_list.append(labels.detach().cpu())
+    if was_training:
+        model.train()
+    if not logits_list:
+        raise ValueError("Cannot compute threshold from an empty dataloader")
+    logits = torch.cat(logits_list, dim=0)
+    targets = torch.cat(targets_list, dim=0)
+    return compute_youden_j_threshold(logits, targets)
+

--- a/tests/test_thresholds.py
+++ b/tests/test_thresholds.py
@@ -1,0 +1,113 @@
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch.utils.data import DataLoader, Dataset
+
+from ssl4polyp.classification.metrics import thresholds
+
+
+def test_compute_youden_threshold_matches_manual_roc():
+    logits = torch.tensor(
+        [
+            [0.0, -1.0],
+            [0.0, 0.1],
+            [0.0, 1.2],
+            [0.0, 2.5],
+            [0.0, -2.0],
+        ]
+    )
+    targets = torch.tensor([0, 0, 1, 1, 0])
+
+    tau = thresholds.compute_youden_j_threshold(logits, targets)
+
+    scores = torch.softmax(logits, dim=1)[:, 1].tolist()
+    targets_np = targets.tolist()
+    preds = [1 if score >= tau else 0 for score in scores]
+
+    tp = sum(int(p == 1 and t == 1) for p, t in zip(preds, targets_np))
+    tn = sum(int(p == 0 and t == 0) for p, t in zip(preds, targets_np))
+    fp = sum(int(p == 1 and t == 0) for p, t in zip(preds, targets_np))
+    fn = sum(int(p == 0 and t == 1) for p, t in zip(preds, targets_np))
+
+    sensitivity = tp / (tp + fn)
+    specificity = tn / (tn + fp)
+    youden = sensitivity + specificity - 1
+
+    brute_force_scores = []
+    for step in range(21):
+        candidate = step / 20
+        brute_preds = [1 if score >= candidate else 0 for score in scores]
+        tp_b = sum(int(p == 1 and t == 1) for p, t in zip(brute_preds, targets_np))
+        tn_b = sum(int(p == 0 and t == 0) for p, t in zip(brute_preds, targets_np))
+        fp_b = sum(int(p == 1 and t == 0) for p, t in zip(brute_preds, targets_np))
+        fn_b = sum(int(p == 0 and t == 1) for p, t in zip(brute_preds, targets_np))
+        sens = tp_b / (tp_b + fn_b) if (tp_b + fn_b) else 0.0
+        spec = tn_b / (tn_b + fp_b) if (tn_b + fp_b) else 0.0
+        brute_force_scores.append(sens + spec - 1)
+
+    assert youden >= max(brute_force_scores) - 1e-6
+
+
+def test_threshold_serialisation_roundtrip(tmp_path):
+    mapping = {"sun_val_youden": 0.42, "polypgen_val_youden": 0.55}
+    out_path = tmp_path / "thresholds.json"
+    thresholds.save_thresholds(out_path, mapping)
+    with out_path.open() as handle:
+        payload = json.load(handle)
+    assert payload["thresholds"]["sun_val_youden"] == pytest.approx(0.42, rel=1e-6)
+
+    loaded = thresholds.load_thresholds(out_path)
+    for key, value in mapping.items():
+        assert loaded[key] == pytest.approx(value, rel=1e-6)
+
+
+def test_format_and_resolve_threshold_key():
+    key = thresholds.format_threshold_key("SUN", "Val", "Youden")
+    assert key == "sun_val_youden"
+    mapping = {key: 0.33}
+    assert thresholds.resolve_threshold(mapping, key) == pytest.approx(0.33, rel=1e-6)
+    assert thresholds.resolve_threshold(mapping, "missing") is None
+
+
+class _ThresholdDataset(Dataset):
+    def __init__(self, logits: torch.Tensor, labels: torch.Tensor):
+        self.logits = logits
+        self.labels = labels
+
+    def __len__(self) -> int:  # pragma: no cover - simple data container
+        return self.labels.shape[0]
+
+    def __getitem__(self, idx):
+        return self.logits[idx], self.labels[idx], {"idx": int(idx)}
+
+
+class _IdentityModel(torch.nn.Module):
+    def forward(self, inputs):  # pragma: no cover - exercised indirectly
+        return inputs
+
+
+def test_compute_threshold_from_loader_matches_direct():
+    logits = torch.tensor(
+        [
+            [1.2, -0.4],
+            [0.3, 0.1],
+            [-0.2, 0.8],
+            [0.1, -1.0],
+        ],
+        dtype=torch.float32,
+    )
+    labels = torch.tensor([1, 0, 1, 0], dtype=torch.long)
+    dataset = _ThresholdDataset(logits, labels)
+    loader = DataLoader(dataset, batch_size=2, shuffle=False)
+    model = _IdentityModel()
+    model.train()
+
+    tau_loader = thresholds.compute_threshold_from_loader(
+        model, loader, torch.device("cpu")
+    )
+    tau_direct = thresholds.compute_youden_j_threshold(logits, labels)
+
+    assert tau_loader == pytest.approx(tau_direct, rel=1e-6)
+    assert model.training, "Model training mode should be restored after threshold computation"


### PR DESCRIPTION
## Summary
- resolve threshold policies automatically for binary tasks during training, returning the computation flags so best-checkpoint updates persist τ alongside weights
- allow eval-time auto and none threshold policies while reusing loader refits and stored keys consistently
- harden loader-based threshold estimation to run without gradients, restore model mode, and cover it with a unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc0203f71c832e92ee08bb23ad2277