### PR TITLE
Add balanced accuracy and AUPRC metrics

### DIFF
--- a/src/ssl4polyp/classification/metrics/performance.py
+++ b/src/ssl4polyp/classification/metrics/performance.py
@@ -1,6 +1,98 @@
+from __future__ import annotations
+
+from typing import Optional
+
 import torch
 import torch.nn as nn
-from sklearn.metrics import roc_auc_score
+import torch.nn.functional as F
+from sklearn.metrics import balanced_accuracy_score, average_precision_score, roc_auc_score
+
+
+_PROB_ATOL = 1e-6
+_PROB_RTOL = 1e-4
+
+
+def _looks_like_probability_vector(tensor: torch.Tensor) -> bool:
+    """Return ``True`` if ``tensor`` appears to contain probabilities."""
+
+    if tensor.numel() == 0:
+        return True
+    min_val = tensor.min().item()
+    max_val = tensor.max().item()
+    return min_val >= -_PROB_ATOL and max_val <= 1.0 + _PROB_ATOL
+
+
+def _looks_like_probability_matrix(tensor: torch.Tensor) -> bool:
+    """Return ``True`` if rows of ``tensor`` resemble probability distributions."""
+
+    if tensor.numel() == 0:
+        return True
+    if not _looks_like_probability_vector(tensor):
+        return False
+    row_sums = tensor.sum(dim=1)
+    ones = torch.ones_like(row_sums)
+    return torch.allclose(row_sums, ones, atol=1e-3, rtol=_PROB_RTOL)
+
+
+def _as_binary_positive_scores(tensor: torch.Tensor) -> torch.Tensor:
+    """Return probabilities for the positive class from binary predictions."""
+
+    if tensor.ndim == 1:
+        if tensor.dtype.is_floating_point:
+            if _looks_like_probability_vector(tensor):
+                return tensor
+            return torch.sigmoid(tensor)
+        return tensor.to(dtype=torch.float32)
+    if tensor.ndim == 2:
+        if tensor.size(1) == 1:
+            return _as_binary_positive_scores(tensor.squeeze(1))
+        if tensor.size(1) != 2:
+            raise ValueError("Binary probability extraction expects tensors with shape (N,), (N, 1) or (N, 2)")
+        if tensor.dtype.is_floating_point and _looks_like_probability_matrix(tensor):
+            probs = tensor
+        else:
+            probs = torch.softmax(tensor.to(dtype=torch.float32), dim=1)
+        return probs[:, 1]
+    raise ValueError("Binary probability extraction expects tensors with 1 or 2 dimensions")
+
+
+def _as_class_probabilities(tensor: torch.Tensor, n_class: int) -> torch.Tensor:
+    """Return class probabilities for multi-class predictions."""
+
+    if tensor.ndim != 2 or tensor.size(1) != n_class:
+        raise ValueError(
+            f"Expected tensor with shape (N, {n_class}) for multi-class probabilities; got {tuple(tensor.shape)}"
+        )
+    if tensor.dtype.is_floating_point and _looks_like_probability_matrix(tensor):
+        return tensor
+    return torch.softmax(tensor.to(dtype=torch.float32), dim=1)
+
+
+def _as_label_predictions(
+    tensor: torch.Tensor,
+    n_class: int,
+    tau: Optional[float] = None,
+) -> torch.Tensor:
+    """Convert ``tensor`` containing logits/probabilities into discrete predictions."""
+
+    if tensor.ndim == 1:
+        if tensor.dtype.is_floating_point and n_class == 2:
+            probs = tensor if _looks_like_probability_vector(tensor) else torch.sigmoid(tensor)
+            threshold = 0.5 if tau is None else tau
+            return (probs >= threshold).to(dtype=torch.long)
+        if tensor.dtype.is_floating_point and n_class != 2:
+            raise ValueError("1D probability tensors are only supported for binary problems")
+        return tensor.to(dtype=torch.long)
+    if tensor.ndim == 2:
+        if tensor.size(1) == 1:
+            return _as_label_predictions(tensor.squeeze(1), n_class, tau)
+        if n_class == 2:
+            probs = _as_binary_positive_scores(tensor)
+            threshold = 0.5 if tau is None else tau
+            return (probs >= threshold).to(dtype=torch.long)
+        probs = _as_class_probabilities(tensor, n_class)
+        return torch.argmax(probs, dim=1)
+    raise ValueError("Prediction tensors must be 1D or 2D")
 
 
 class meanF1Score(nn.Module):
@@ -86,4 +178,40 @@ class meanAUROC(nn.Module):
                 targets_np, preds_np, multi_class="ovr", average="macro"
             )
         return torch.tensor(score)
+
+
+class meanBalancedAccuracy(nn.Module):
+    """Compute balanced accuracy across classes."""
+
+    def __init__(self, n_class: int):
+        super().__init__()
+        self.n_class = n_class
+
+    def forward(self, preds: torch.Tensor, targets: torch.Tensor, *, tau: Optional[float] = None):
+        labels = _as_label_predictions(preds.detach(), self.n_class, tau)
+        labels_np = labels.cpu().numpy()
+        targets_np = targets.detach().cpu().numpy()
+        score = balanced_accuracy_score(targets_np, labels_np)
+        return torch.tensor(score, dtype=torch.float32)
+
+
+class meanAUPRC(nn.Module):
+    """Compute macro-averaged area under the precision-recall curve."""
+
+    def __init__(self, n_class: int):
+        super().__init__()
+        self.n_class = n_class
+
+    def forward(self, preds: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        targets_np = targets.detach().cpu().numpy()
+        if self.n_class == 2:
+            scores = _as_binary_positive_scores(preds.detach())
+            score = average_precision_score(targets_np, scores.cpu().numpy())
+            return torch.tensor(score, dtype=torch.float32)
+        probs = _as_class_probabilities(preds.detach(), self.n_class)
+        one_hot = F.one_hot(targets.to(dtype=torch.long), num_classes=self.n_class)
+        score = average_precision_score(
+            one_hot.cpu().numpy(), probs.cpu().numpy(), average="macro"
+        )
+        return torch.tensor(score, dtype=torch.float32)
 

--- a/tests/test_performance_metrics.py
+++ b/tests/test_performance_metrics.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from sklearn.metrics import average_precision_score, balanced_accuracy_score
+
+from ssl4polyp.classification.metrics.performance import meanAUPRC, meanBalancedAccuracy
+
+
+def test_balanced_accuracy_binary_with_tau():
+    probs = torch.tensor(
+        [
+            [0.9, 0.1],
+            [0.2, 0.8],
+            [0.65, 0.35],
+            [0.45, 0.55],
+        ]
+    )
+    targets = torch.tensor([0, 1, 0, 1])
+    metric = meanBalancedAccuracy(n_class=2)
+    score = metric(probs, targets, tau=0.6).item()
+
+    # Apply threshold manually to verify the helper respects ``tau``.
+    manual_preds = (probs[:, 1] >= 0.6).long()
+    expected = balanced_accuracy_score(targets.numpy(), manual_preds.numpy())
+
+    assert score == pytest.approx(expected)
+
+
+def test_balanced_accuracy_accepts_logits():
+    logits = torch.tensor(
+        [
+            [2.0, 1.0],
+            [0.0, 3.0],
+            [3.0, 0.0],
+            [1.0, 2.0],
+        ]
+    )
+    targets = torch.tensor([0, 1, 0, 1])
+    metric = meanBalancedAccuracy(n_class=2)
+    score = metric(logits, targets).item()
+
+    probs = torch.softmax(logits, dim=1)
+    expected = balanced_accuracy_score(targets.numpy(), probs.argmax(dim=1).numpy())
+
+    assert score == pytest.approx(expected)
+
+
+def test_balanced_accuracy_multiclass_probabilities():
+    probs = torch.tensor(
+        [
+            [0.7, 0.2, 0.1],
+            [0.1, 0.8, 0.1],
+            [0.2, 0.3, 0.5],
+            [0.05, 0.1, 0.85],
+        ]
+    )
+    targets = torch.tensor([0, 1, 2, 2])
+    metric = meanBalancedAccuracy(n_class=3)
+    score = metric(probs, targets).item()
+
+    expected = balanced_accuracy_score(targets.numpy(), probs.argmax(dim=1).numpy())
+
+    assert score == pytest.approx(expected)
+
+
+def test_mauprc_binary_logits():
+    logits = torch.tensor(
+        [
+            [2.0, 1.0],
+            [1.0, 2.0],
+            [3.0, 0.5],
+            [0.2, 1.8],
+        ]
+    )
+    targets = torch.tensor([0, 1, 0, 1])
+    metric = meanAUPRC(n_class=2)
+    score = metric(logits, targets).item()
+
+    probs = torch.softmax(logits, dim=1)[:, 1]
+    expected = average_precision_score(targets.numpy(), probs.numpy())
+
+    assert score == pytest.approx(expected)
+
+
+def test_mauprc_multiclass_probabilities():
+    probs = torch.tensor(
+        [
+            [0.8, 0.1, 0.1],
+            [0.2, 0.7, 0.1],
+            [0.1, 0.2, 0.7],
+            [0.6, 0.2, 0.2],
+            [0.15, 0.7, 0.15],
+        ]
+    )
+    targets = torch.tensor([0, 1, 2, 0, 1])
+    metric = meanAUPRC(n_class=3)
+    score = metric(probs, targets).item()
+
+    one_hot = torch.nn.functional.one_hot(targets, num_classes=3).numpy()
+    expected = average_precision_score(one_hot, probs.numpy(), average="macro")
+
+    assert score == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- add helpers plus balanced accuracy and AUPRC modules that accept logits or probabilities
- extend the classification evaluation routine to compute, print and persist the new metrics alongside existing ones
- cover the new helpers with unit tests validating binary thresholds, logits and multiclass inputs

## Testing
- pytest tests/test_performance_metrics.py *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68cc18109644832eb7a3ce924410bec0