### PR TITLE
Support multi-seed experiments and metric aggregation

### DIFF
--- a/scripts/aggregate_metrics.py
+++ b/scripts/aggregate_metrics.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+"""Aggregate per-seed metric exports and compute summary statistics."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import random
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping
+
+
+def _load_metric_files(directory: Path) -> List[Path]:
+    if not directory.exists():
+        return []
+    return sorted(p for p in directory.iterdir() if p.suffix == ".json" and p.is_file())
+
+
+def _quantile(sorted_values: List[float], q: float) -> float:
+    if not sorted_values:
+        raise ValueError("Cannot compute quantile of empty sample")
+    if q <= 0:
+        return sorted_values[0]
+    if q >= 1:
+        return sorted_values[-1]
+    pos = q * (len(sorted_values) - 1)
+    lower = math.floor(pos)
+    upper = math.ceil(pos)
+    if lower == upper:
+        return sorted_values[lower]
+    fraction = pos - lower
+    return sorted_values[lower] + (sorted_values[upper] - sorted_values[lower]) * fraction
+
+
+def _aggregate_metric(values: Iterable[float], ci: float, bootstrap: int, rng_seed: int) -> Mapping[str, float]:
+    samples = [float(v) for v in values]
+    n = len(samples)
+    if n == 0:
+        raise ValueError("Cannot aggregate an empty set of values")
+    mean = float(statistics.fmean(samples))
+    std = float(statistics.stdev(samples)) if n > 1 else 0.0
+    if n == 1 or bootstrap <= 0:
+        lower = upper = mean
+    else:
+        rng = random.Random(rng_seed)
+        boot_means = []
+        for _ in range(bootstrap):
+            draw = [samples[rng.randrange(n)] for _ in range(n)]
+            boot_means.append(float(statistics.fmean(draw)))
+        boot_means.sort()
+        alpha = (1.0 - ci) / 2.0
+        lower = float(_quantile(boot_means, alpha))
+        upper = float(_quantile(boot_means, 1.0 - alpha))
+    return {"mean": mean, "std": std, "ci_lower": lower, "ci_upper": upper}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Aggregate per-seed metrics into summary statistics",
+    )
+    parser.add_argument(
+        "--metrics-root",
+        type=Path,
+        default=Path("results/classification"),
+        help="Directory containing per-experiment seed metrics",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Destination for the aggregated CSV (defaults to metrics-root/summary.csv)",
+    )
+    parser.add_argument(
+        "--metric-key",
+        choices=["test", "val"],
+        default="test",
+        help="Which metric block to aggregate (default: test)",
+    )
+    parser.add_argument(
+        "--bootstrap",
+        type=int,
+        default=1000,
+        help="Number of bootstrap samples to compute confidence intervals (default: 1000)",
+    )
+    parser.add_argument(
+        "--ci",
+        type=float,
+        default=0.95,
+        help="Confidence level for bootstrap intervals (default: 0.95)",
+    )
+    parser.add_argument(
+        "--rng-seed",
+        type=int,
+        default=12345,
+        help="Seed for the bootstrap RNG (default: 12345)",
+    )
+    args = parser.parse_args()
+
+    metrics_root = args.metrics_root
+    output_path = args.output if args.output is not None else metrics_root / "summary.csv"
+
+    experiments: Dict[str, Dict[str, List[float]]] = {}
+    seed_registry: Dict[str, List[int]] = {}
+
+    if not metrics_root.exists():
+        raise FileNotFoundError(f"Metrics root directory does not exist: {metrics_root}")
+
+    for experiment_dir in sorted(p for p in metrics_root.iterdir() if p.is_dir()):
+        metric_values: Dict[str, List[float]] = defaultdict(list)
+        seeds: List[int] = []
+        for metrics_path in _load_metric_files(experiment_dir):
+            with open(metrics_path, "r") as handle:
+                payload = json.load(handle)
+            seed = int(payload.get("seed")) if payload.get("seed") is not None else None
+            if seed is not None:
+                seeds.append(seed)
+            block = payload.get(args.metric_key, {})
+            for metric_name, value in block.items():
+                metric_values[metric_name].append(float(value))
+        if metric_values:
+            experiments[experiment_dir.name] = metric_values
+            seed_registry[experiment_dir.name] = sorted(set(seeds))
+
+    if not experiments:
+        raise RuntimeError(f"No metrics found in {metrics_root}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "experiment",
+                "metric",
+                "n",
+                "mean",
+                "std",
+                "ci_lower",
+                "ci_upper",
+                "seeds",
+            ],
+        )
+        writer.writeheader()
+        for experiment, metrics in experiments.items():
+            for metric_name, values in sorted(metrics.items()):
+                summary = _aggregate_metric(values, args.ci, args.bootstrap, args.rng_seed)
+                writer.writerow(
+                    {
+                        "experiment": experiment,
+                        "metric": metric_name,
+                        "n": len(values),
+                        "mean": summary["mean"],
+                        "std": summary["std"],
+                        "ci_lower": summary["ci_lower"],
+                        "ci_upper": summary["ci_upper"],
+                        "seeds": ",".join(str(s) for s in seed_registry.get(experiment, [])),
+                    }
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_exps.sh
+++ b/scripts/run_exps.sh
@@ -9,63 +9,92 @@ PY
 REPO_ROOT=$(dirname "$CONFIG_ROOT")
 DEFAULT_ROOTS_JSON="${REPO_ROOT}/data/roots.json"
 DEFAULT_OUT_BASE="${REPO_ROOT}/checkpoints/classification"
+DEFAULT_RESULTS_BASE="${REPO_ROOT}/results/classification"
 
-# Run experiments Exp-1..Exp-5 using manifests and a roots mapping.
-# Usage: scripts/run_exps.sh MANIFEST_DIR [ROOTS_JSON] [OUT_BASE]
-# MANIFEST_DIR: Directory containing manifest YAML files exp1.yaml..exp5.yaml
-# ROOTS_JSON: JSON file mapping root identifiers to filesystem paths
-#             (default: data/roots.json)
-# OUT_BASE: Base directory for experiment outputs
-#           (default: checkpoints/classification)
-
-if [[ $# -lt 1 || $# -gt 3 ]]; then
-  echo "Usage: $0 MANIFEST_DIR [ROOTS_JSON] [OUT_BASE]" >&2
+# Usage: scripts/run_exps.sh EXP_CONFIG_DIR [ROOTS_JSON] [OUT_BASE] [RESULTS_BASE]
+if [[ $# -lt 1 || $# -gt 4 ]]; then
+  echo "Usage: $0 EXP_CONFIG_DIR [ROOTS_JSON] [OUT_BASE] [RESULTS_BASE]" >&2
   exit 1
 fi
 
-MANIFEST_DIR="$1"
-if [[ "$MANIFEST_DIR" != /* && ! -e "$MANIFEST_DIR" ]]; then
-  MANIFEST_DIR="${CONFIG_ROOT}/${MANIFEST_DIR}"
+EXP_DIR="$1"
+if [[ "$EXP_DIR" != /* && ! -e "$EXP_DIR" ]]; then
+  EXP_DIR="${CONFIG_ROOT}/${EXP_DIR}"
 fi
 ROOTS_JSON="${2:-$DEFAULT_ROOTS_JSON}"
 if [[ "$ROOTS_JSON" != /* && ! -e "$ROOTS_JSON" ]]; then
-  ROOTS_JSON="${CONFIG_ROOT}/${ROOTS_JSON}"
+  ROOTS_JSON="${REPO_ROOT}/${ROOTS_JSON}"
 fi
 OUT_BASE="${3:-$DEFAULT_OUT_BASE}"
+RESULTS_BASE="${4:-$DEFAULT_RESULTS_BASE}"
 
-CSV="joblist.csv"
-# Initialize joblist.csv with header if it doesn't exist
-if [[ ! -f "$CSV" ]]; then
-  echo "exp,manifest,output_dir" > "$CSV"
+if [[ ! -d "$EXP_DIR" ]]; then
+  echo "Experiment configuration directory not found: $EXP_DIR" >&2
+  exit 1
+fi
+if [[ ! -f "$ROOTS_JSON" ]]; then
+  echo "Roots mapping not found: $ROOTS_JSON" >&2
+  exit 1
 fi
 
-for EXP in 1 2 3 4 5; do
-  MANIFEST_PATH="${MANIFEST_DIR}/exp${EXP}.yaml"
-  OUT_DIR="${OUT_BASE}/exp${EXP}"
+mapfile -t EXP_CONFIGS < <(python - "$EXP_DIR" <<'PY'
+import pathlib
+import sys
 
-  echo "${EXP},${MANIFEST_PATH},${OUT_DIR}" >> "$CSV"
+exp_dir = pathlib.Path(sys.argv[1])
+for path in sorted(exp_dir.glob("*.yaml")):
+    print(path)
+PY
+)
 
-  # Extract CSV paths from the manifest and ensure all referenced files exist
-  mapfile -t CSV_FILES < <(
-    python - "$MANIFEST_PATH" <<'PY'
-import sys, yaml, pathlib
-manifest = pathlib.Path(sys.argv[1])
-with open(manifest) as f:
-    data = yaml.safe_load(f) or {}
-for entry in data.values():
-    if isinstance(entry, dict) and "csv" in entry:
-        p = pathlib.Path(entry["csv"])
-        if not p.is_absolute():
-            p = manifest.parent / p
-        print(p)
+if [[ ${#EXP_CONFIGS[@]} -eq 0 ]]; then
+  echo "No experiment configurations found in $EXP_DIR" >&2
+  exit 1
+fi
+
+for CONFIG_PATH in "${EXP_CONFIGS[@]}"; do
+  EXP_NAME=$(basename "${CONFIG_PATH%.*}")
+  echo "Launching experiment ${EXP_NAME}"
+  mapfile -t SEEDS < <(python - "$CONFIG_PATH" <<'PY'
+import sys
+from ssl4polyp.configs.layered import load_layered_config
+
+cfg = load_layered_config(sys.argv[1])
+raw_seeds = cfg.get("seeds")
+if raw_seeds is None:
+    seed = cfg.get("seed")
+    raw_seeds = [seed] if seed is not None else []
+if isinstance(raw_seeds, int):
+    raw_seeds = [raw_seeds]
+if isinstance(raw_seeds, str):
+    parts = [p for p in raw_seeds.replace(',', ' ').split() if p]
+    raw_seeds = [int(p) for p in parts]
+else:
+    raw_seeds = [int(s) for s in raw_seeds]
+for seed in raw_seeds:
+    print(seed)
 PY
   )
-  for CSV_FILE in "${CSV_FILES[@]}"; do
-    python scripts/check_paths.py "$CSV_FILE" "$ROOTS_JSON"
+  if [[ ${#SEEDS[@]} -eq 0 ]]; then
+    echo "No seeds specified for $CONFIG_PATH; skipping" >&2
+    continue
+  fi
+  for SEED in "${SEEDS[@]}"; do
+    OUT_DIR="${OUT_BASE}/${EXP_NAME}/seed${SEED}"
+    mkdir -p "$OUT_DIR"
+    echo "  -> seed ${SEED}"
+    python -m ssl4polyp.classification.train_classification \
+      --exp-config "$CONFIG_PATH" \
+      --seed "$SEED" \
+      --output-dir "$OUT_DIR" \
+      --roots "$ROOTS_JSON"
+    METRICS_SRC="${OUT_DIR}/metrics.json"
+    if [[ ! -f "$METRICS_SRC" ]]; then
+      echo "Metrics export missing for ${CONFIG_PATH} seed ${SEED}" >&2
+      exit 1
+    fi
+    RESULTS_DIR="${RESULTS_BASE}/${EXP_NAME}"
+    mkdir -p "$RESULTS_DIR"
+    cp "$METRICS_SRC" "${RESULTS_DIR}/seed${SEED}.json"
   done
-
-  python -m ssl4polyp.classification.train_classification \
-    --manifest "$MANIFEST_PATH" \
-    --roots "$ROOTS_JSON" \
-    --output-dir "$OUT_DIR"
 done

--- a/tests/test_metric_aggregation.py
+++ b/tests/test_metric_aggregation.py
@@ -1,0 +1,65 @@
+import csv
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def load_aggregate_module(repo_root: Path):
+    module_path = repo_root / "scripts" / "aggregate_metrics.py"
+    spec = importlib.util.spec_from_file_location("aggregate_metrics", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_aggregate_metrics(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    metrics_root = tmp_path / "results" / "classification"
+    exp_dir = metrics_root / "exp_alpha"
+    exp_dir.mkdir(parents=True)
+
+    samples = [
+        {"seed": 1, "test": {"auroc": 0.9, "f1": 0.8}},
+        {"seed": 2, "test": {"auroc": 0.7, "f1": 0.6}},
+        {"seed": 3, "test": {"auroc": 0.85, "f1": 0.75}},
+    ]
+    for sample in samples:
+        with open(exp_dir / f"seed{sample['seed']}.json", "w") as f:
+            json.dump(sample, f)
+
+    agg_module = load_aggregate_module(repo_root)
+    expected = agg_module._aggregate_metric([s["test"]["auroc"] for s in samples], 0.95, 100, 0)
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "scripts" / "aggregate_metrics.py"),
+            "--metrics-root",
+            str(metrics_root),
+            "--bootstrap",
+            "100",
+            "--rng-seed",
+            "0",
+        ],
+        cwd=repo_root,
+        check=True,
+    )
+
+    summary_path = metrics_root / "summary.csv"
+    assert summary_path.exists()
+    with open(summary_path, newline="") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 2  # auroc and f1
+
+    row_map = {row["metric"]: row for row in rows}
+    auroc_row = row_map["auroc"]
+    assert auroc_row["experiment"] == "exp_alpha"
+    assert auroc_row["n"] == "3"
+    assert auroc_row["seeds"] == "1,2,3"
+    assert abs(float(auroc_row["mean"]) - expected["mean"]) < 1e-9
+    assert abs(float(auroc_row["std"]) - expected["std"]) < 1e-9
+    assert abs(float(auroc_row["ci_lower"]) - expected["ci_lower"]) < 1e-9
+    assert abs(float(auroc_row["ci_upper"]) - expected["ci_upper"]) < 1e-9


### PR DESCRIPTION
## Summary
- add CLI support for multi-seed execution in `train_classification.py` and export per-seed metrics
- update `scripts/run_exps.sh` to iterate experiment seeds, route outputs, and collect metric exports
- introduce a reusable `aggregate_metrics.py` helper with tests to summarise per-seed results

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'torch')*
- pytest tests/test_metric_aggregation.py

------
https://chatgpt.com/codex/tasks/task_e_68cc19efdf20832e9bd933392736a56e