### PR TITLE
Refine classification evaluation checkpoint discovery

### DIFF
--- a/src/ssl4polyp/classification/eval_classification.py
+++ b/src/ssl4polyp/classification/eval_classification.py
@@ -1,10 +1,11 @@
-import os
 import argparse
 import csv
 import json
+import re
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import torch
 
@@ -12,6 +13,443 @@ from ssl4polyp import utils
 from ssl4polyp.classification.data import create_classification_dataloaders
 from ssl4polyp.classification.metrics import performance, thresholds as threshold_utils
 from ssl4polyp.configs import data_packs_root
+
+
+CHECKPOINT_NAME_RE = re.compile(
+    r"""
+    ^
+    (?P<model_tag>[0-9A-Za-z]+)
+    __
+    (?P<data_tag>[0-9A-Za-z]+)
+    (?P<qualifiers>(?:_[0-9A-Za-z]+)*)
+    _s(?P<seed>\d+)
+    (?:
+        _e(?P<epoch>\d+)
+        _(?P<best_tag>[0-9A-Za-z]+)
+        (?:\+(?P<digest>[0-9A-Za-z]+))?
+    )?
+    $
+    """,
+    re.VERBOSE,
+)
+
+
+@dataclass(frozen=True)
+class CheckpointCandidate:
+    """Metadata extracted from a canonical checkpoint path."""
+
+    path: Path
+    model_tag: str
+    data_tag: str
+    seed: int
+    qualifiers: Tuple[str, ...]
+    best_tag: Optional[str]
+    epoch: Optional[int]
+    digest: Optional[str]
+    relative_dir: Tuple[str, ...]
+
+
+def _normalise_canonical(tag: Optional[str]) -> Optional[str]:
+    if tag is None:
+        return None
+    text = re.sub(r"[^0-9A-Za-z]+", "", str(tag)).lower()
+    return text or None
+
+
+def _normalise_path_segment(raw: Optional[str]) -> str:
+    if raw is None:
+        return ""
+    text = str(raw).strip()
+    if not text:
+        return ""
+    cleaned = re.sub(r"[^0-9A-Za-z]+", "_", text.lower()).strip("_")
+    return cleaned
+
+
+def _normalise_pack_to_segments(pack: Optional[str]) -> set[str]:
+    segments: set[str] = set()
+    if not pack:
+        return segments
+    pieces = str(pack).replace("\\", "/").split("/")
+    for piece in pieces:
+        segment = _normalise_path_segment(piece)
+        if segment:
+            segments.add(segment)
+    return segments
+
+
+def _parse_checkpoint_stem(stem: str) -> Optional[Dict[str, Any]]:
+    match = CHECKPOINT_NAME_RE.match(stem)
+    if not match:
+        return None
+    qualifiers_raw = match.group("qualifiers") or ""
+    qualifiers: Tuple[str, ...] = tuple(
+        part for part in qualifiers_raw.split("_") if part
+    )
+    epoch = match.group("epoch")
+    digest = match.group("digest")
+    return {
+        "model_tag": match.group("model_tag"),
+        "data_tag": match.group("data_tag"),
+        "seed": int(match.group("seed")),
+        "qualifiers": qualifiers,
+        "best_tag": match.group("best_tag"),
+        "epoch": int(epoch) if epoch is not None else None,
+        "digest": digest,
+    }
+
+
+def _discover_checkpoints(root: Path) -> List[CheckpointCandidate]:
+    root = Path(root).expanduser()
+    if not root.exists():
+        return []
+    seen: set[Path] = set()
+    raw: list[CheckpointCandidate] = []
+    for path in sorted(root.rglob("*.pth")):
+        try:
+            resolved = path.resolve(strict=False)
+        except OSError:
+            resolved = path
+        if resolved in seen:
+            continue
+        if not resolved.exists():
+            continue
+        metadata = _parse_checkpoint_stem(resolved.stem)
+        if not metadata:
+            continue
+        seen.add(resolved)
+        try:
+            relative_parts = path.relative_to(root).parts[:-1]
+        except ValueError:
+            try:
+                relative_parts = resolved.relative_to(root).parts[:-1]
+            except ValueError:
+                relative_parts = resolved.parent.parts
+        candidate = CheckpointCandidate(
+            path=resolved,
+            relative_dir=tuple(relative_parts),
+            **metadata,
+        )
+        raw.append(candidate)
+
+    grouped: Dict[Tuple[str, str, int], List[CheckpointCandidate]] = {}
+    for item in raw:
+        key = (item.model_tag, item.data_tag, item.seed)
+        grouped.setdefault(key, []).append(item)
+
+    result: List[CheckpointCandidate] = []
+    for items in grouped.values():
+        with_best = [entry for entry in items if entry.best_tag]
+        if with_best:
+            result.extend(with_best)
+        else:
+            result.extend(items)
+
+    result.sort(
+        key=lambda c: (
+            _normalise_canonical(c.model_tag) or "",
+            _normalise_canonical(c.data_tag) or "",
+            c.seed,
+            c.epoch if c.epoch is not None else -1,
+            str(c.path),
+        )
+    )
+    return result
+
+
+def _format_candidate(candidate: CheckpointCandidate) -> str:
+    parts = [candidate.model_tag, candidate.data_tag, f"s{candidate.seed}"]
+    if candidate.best_tag:
+        parts.append(candidate.best_tag)
+    rel_dir = "/".join(candidate.relative_dir)
+    descriptor = ", ".join(parts)
+    if rel_dir:
+        return f"{candidate.path} ({rel_dir}: {descriptor})"
+    return f"{candidate.path} ({descriptor})"
+
+
+def _filter_candidates(
+    candidates: Iterable[CheckpointCandidate],
+    *,
+    model_filter: Optional[str],
+    data_filter: Optional[str],
+    seed_filter: Optional[int],
+    best_filter: Optional[str],
+    pack_filters: set[str],
+) -> List[CheckpointCandidate]:
+    filtered: List[CheckpointCandidate] = []
+    pack_matched: List[CheckpointCandidate] = []
+    pack_unmatched: List[CheckpointCandidate] = []
+    for candidate in candidates:
+        if model_filter and (
+            _normalise_canonical(candidate.model_tag) != model_filter
+        ):
+            continue
+        if data_filter and (
+            _normalise_canonical(candidate.data_tag) != data_filter
+        ):
+            continue
+        if seed_filter is not None and candidate.seed != seed_filter:
+            continue
+        if best_filter is not None:
+            best_tag = _normalise_canonical(candidate.best_tag)
+            if best_tag != best_filter:
+                continue
+        if pack_filters:
+            segments = {
+                _normalise_path_segment(part) for part in candidate.relative_dir
+            }
+            if segments & pack_filters:
+                pack_matched.append(candidate)
+            else:
+                pack_unmatched.append(candidate)
+                continue
+        filtered.append(candidate)
+    if pack_filters:
+        if pack_matched:
+            return pack_matched
+        return pack_unmatched
+    return filtered
+
+
+def _compose_legacy_checkpoint_path(args, checkpoint_dir: Path) -> Path:
+    if args.ss_framework:
+        ckpt_name = (
+            f"{args.arch}-{args.pretraining}_{args.ss_framework}_"
+            f"init-frozen_{str(False)}-dataset_{args.dataset}.pth"
+        )
+    else:
+        ckpt_name = (
+            f"{args.arch}-{args.pretraining}_"
+            f"init-frozen_{str(False)}-dataset_{args.dataset}.pth"
+        )
+    return checkpoint_dir / ckpt_name
+
+
+def _sanitize_path_segment(raw: Any, *, default: str = "default") -> str:
+    text = str(raw).strip() if raw is not None else ""
+    if not text:
+        return default
+    text = text.strip("/ ")
+    if "/" in text:
+        text = text.split("/")[-1]
+    cleaned = re.sub(r"[^0-9A-Za-z._-]+", "_", text).strip("._-")
+    return cleaned.lower() if cleaned else default
+
+
+def _search_int(pattern: str, *candidates: Optional[str]) -> Optional[int]:
+    for text in candidates:
+        if not text:
+            continue
+        match = re.search(pattern, str(text), flags=re.IGNORECASE)
+        if match:
+            try:
+                return int(match.group(1))
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def _resolve_thresholds_subdir(args, checkpoint: CheckpointCandidate) -> str:
+    if getattr(args, "threshold_pack", None):
+        segment = _sanitize_path_segment(args.threshold_pack, default="")
+        if segment and segment != "default":
+            return segment
+
+    dataset_name = getattr(args, "threshold_dataset", None) or getattr(
+        args, "dataset", None
+    )
+    dataset_key = str(dataset_name or "").lower()
+    parts: List[str] = []
+
+    if dataset_key == "sun_full":
+        parts.append("sun")
+    elif dataset_key:
+        segment = _sanitize_path_segment(dataset_key, default="dataset")
+        if segment and segment != "default":
+            parts.append(segment)
+
+    percent = _search_int(
+        r"p(\d+)", args.threshold_pack, args.test_pack, checkpoint.data_tag
+    )
+    dataset_seed = _search_int(r"seed(\d+)", args.threshold_pack, args.test_pack)
+    size = _search_int(
+        r"few(\d+)", args.threshold_pack, args.test_pack, checkpoint.data_tag
+    )
+    if size is None:
+        size = _search_int(r"_s(\d+)", args.threshold_pack, args.test_pack)
+
+    if dataset_key.startswith("polypgen_fewshot"):
+        if size is not None:
+            parts.append(f"c{int(size)}")
+        if dataset_seed is not None:
+            parts.append(f"s{int(dataset_seed)}")
+    elif dataset_key.startswith("sun_subsets"):
+        if percent is not None:
+            parts.append(f"p{int(percent)}")
+        if dataset_seed is not None:
+            parts.append(f"s{int(dataset_seed)}")
+
+    if not parts:
+        fallback = _sanitize_path_segment(checkpoint.data_tag, default="dataset")
+        if fallback:
+            parts.append(fallback)
+
+    if len(parts) == 1:
+        split = getattr(args, "threshold_split", None) or "val"
+        parts.append(_sanitize_path_segment(split, default="val"))
+
+    return "_".join(parts)
+
+
+def _load_threshold_metadata(path: Path) -> Dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("Threshold metadata must be a JSON object")
+    if "selected_threshold" not in payload:
+        raise ValueError("Threshold metadata missing 'selected_threshold'")
+    try:
+        selected_threshold = float(payload["selected_threshold"])
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Selected threshold must be numeric") from exc
+
+    metadata: Dict[str, Any] = dict(payload)
+    metadata["selected_threshold"] = selected_threshold
+
+    threshold_key = metadata.get("threshold_key")
+    if threshold_key is not None:
+        metadata["threshold_key"] = str(threshold_key)
+
+    thresholds_raw = metadata.get("thresholds") or {}
+    if thresholds_raw and not isinstance(thresholds_raw, dict):
+        raise ValueError("Threshold metadata 'thresholds' field must be an object")
+    thresholds_map: Dict[str, float] = {}
+    for key, value in (thresholds_raw or {}).items():
+        try:
+            thresholds_map[str(key)] = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Invalid threshold value for key {key!r}: {value!r}"
+            ) from exc
+
+    metadata["thresholds"] = thresholds_map
+
+    key = metadata.get("threshold_key")
+    if key and key not in thresholds_map:
+        thresholds_map[key] = selected_threshold
+
+    if "metrics_at_threshold" in metadata:
+        metrics = metadata["metrics_at_threshold"]
+        if metrics is not None and not isinstance(metrics, dict):
+            raise ValueError("'metrics_at_threshold' must be an object")
+        if isinstance(metrics, dict):
+            cleaned_metrics: Dict[str, Optional[float]] = {}
+            for name, value in metrics.items():
+                if value is None:
+                    cleaned_metrics[str(name)] = None
+                    continue
+                try:
+                    cleaned_metrics[str(name)] = float(value)
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        f"Invalid metric value for key {name!r}: {value!r}"
+                    ) from exc
+            metadata["metrics_at_threshold"] = cleaned_metrics
+
+    if "seed" in metadata and metadata["seed"] is not None:
+        try:
+            metadata["seed"] = int(metadata["seed"])
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Threshold metadata seed must be an integer") from exc
+
+    metadata["path"] = Path(path)
+    return metadata
+
+
+def _find_threshold_metadata(
+    root: Path,
+    model_tag: str,
+    *,
+    expected_directory: Optional[str],
+    pack_filters: set[str],
+) -> List[Dict[str, Any]]:
+    root = Path(root).expanduser()
+    pattern = f"{model_tag}.json"
+    matches: List[Dict[str, Any]] = []
+    for path in sorted(root.rglob(pattern)):
+        try:
+            metadata = _load_threshold_metadata(path)
+        except ValueError as exc:
+            raise ValueError(f"Failed to load threshold metadata from {path}: {exc}") from exc
+
+        model_in_file = metadata.get("model_tag")
+        if model_in_file and (
+            _normalise_canonical(model_in_file)
+            != _normalise_canonical(model_tag)
+        ):
+            continue
+
+        directory = metadata.get("directory")
+        if expected_directory and directory:
+            if _normalise_path_segment(directory) != _normalise_path_segment(
+                expected_directory
+            ):
+                continue
+
+        if pack_filters:
+            candidate_pack = metadata.get("data_pack")
+            if candidate_pack:
+                candidate_segments = _normalise_pack_to_segments(candidate_pack)
+                if not candidate_segments & pack_filters:
+                    continue
+
+        matches.append(metadata)
+
+    return matches
+
+
+def _resolve_threshold_metadata(
+    args,
+    checkpoint: Optional[CheckpointCandidate],
+    checkpoint_dir: Path,
+) -> Optional[Dict[str, Any]]:
+    if checkpoint is None:
+        return None
+    checkpoint_dir = Path(checkpoint_dir).expanduser()
+    candidates = [checkpoint_dir / "thresholds", checkpoint_dir.parent / "thresholds"]
+    thresholds_root: Optional[Path] = None
+    for candidate in candidates:
+        if candidate.exists():
+            thresholds_root = candidate
+            break
+    if thresholds_root is None:
+        thresholds_root = candidates[0]
+
+    expected_subdir = _resolve_thresholds_subdir(args, checkpoint)
+    candidate_path = thresholds_root / expected_subdir / f"{checkpoint.model_tag}.json"
+
+    metadata: Optional[Dict[str, Any]] = None
+    if candidate_path.exists():
+        metadata = _load_threshold_metadata(candidate_path)
+    else:
+        pack_filters = _normalise_pack_to_segments(getattr(args, "threshold_pack", None))
+        matches = _find_threshold_metadata(
+            thresholds_root,
+            checkpoint.model_tag,
+            expected_directory=expected_subdir,
+            pack_filters=pack_filters,
+        )
+        if len(matches) == 1:
+            metadata = matches[0]
+        elif len(matches) > 1:
+            options = ", ".join(str(m["path"]) for m in matches)
+            raise RuntimeError(
+                "Multiple threshold metadata files matched for model tag "
+                f"'{checkpoint.model_tag}': {options}"
+            )
+
+    return metadata
 
 
 @torch.no_grad()
@@ -189,28 +627,55 @@ def build(args):
     else:
         raise ValueError(f"Unsupported pretraining option '{args.pretraining}'")
 
-    checkpoint_dir = Path(args.checkpoint_dir)
-    if args.ss_framework:
-        ckpt_name = (
-            f"{args.arch}-{args.pretraining}_{args.ss_framework}_"
-            f"init-frozen_{str(False)}-dataset_{args.dataset}.pth"
+    checkpoint_dir = Path(args.checkpoint_dir).expanduser()
+    candidates = _discover_checkpoints(checkpoint_dir)
+    selected_candidate: Optional[CheckpointCandidate] = None
+    if candidates:
+        model_filter = _normalise_canonical(getattr(args, "model_tag", None))
+        data_filter = _normalise_canonical(getattr(args, "data_tag", None))
+        seed_filter = getattr(args, "seed", None)
+        best_filter = _normalise_canonical(getattr(args, "best_tag", None))
+        pack_filters = _normalise_pack_to_segments(getattr(args, "test_pack", None))
+
+        filtered = _filter_candidates(
+            candidates,
+            model_filter=model_filter,
+            data_filter=data_filter,
+            seed_filter=seed_filter,
+            best_filter=best_filter,
+            pack_filters=pack_filters,
         )
+        if not filtered:
+            available = "\n".join(f"  - {_format_candidate(c)}" for c in candidates)
+            raise ValueError(
+                "No canonical checkpoints matched the provided filters. "
+                "Supply --model-tag/--data-tag/--seed/--best-tag to disambiguate. "
+                f"Available checkpoints:\n{available}"
+            )
+        if len(filtered) > 1:
+            options = "\n".join(f"  - {_format_candidate(c)}" for c in filtered)
+            raise ValueError(
+                "Multiple checkpoints matched the requested filters. "
+                "Refine your selection with --model-tag, --data-tag, --seed or --best-tag. "
+                f"Matches:\n{options}"
+            )
+        selected_candidate = filtered[0]
+        ckpt_path = selected_candidate.path
     else:
-        ckpt_name = (
-            f"{args.arch}-{args.pretraining}_"
-            f"init-frozen_{str(False)}-dataset_{args.dataset}.pth"
-        )
-    ckpt_path = checkpoint_dir / ckpt_name
-    if not ckpt_path.exists():
-        raise FileNotFoundError(
-            f"Checkpoint not found at {ckpt_path}. Adjust --checkpoint-dir or provide --checkpoint manually."
-        )
+        ckpt_path = _compose_legacy_checkpoint_path(args, checkpoint_dir)
+        if not ckpt_path.exists():
+            raise FileNotFoundError(
+                f"Checkpoint not found at {ckpt_path}. Adjust filters or --checkpoint-dir."
+            )
 
     checkpoint = torch.load(str(ckpt_path), map_location="cpu")
     model.load_state_dict(checkpoint["model_state_dict"])
     model.to(device)
 
     thresholds_map = dict(checkpoint.get("thresholds", {}) or {})
+    threshold_metadata = _resolve_threshold_metadata(args, selected_candidate, checkpoint_dir)
+    if threshold_metadata:
+        thresholds_map.update(threshold_metadata.get("thresholds", {}))
     tau_json = ckpt_path.with_suffix(".thresholds.json")
     if tau_json.exists():
         try:
@@ -340,6 +805,30 @@ def get_args():
     )
     parser.add_argument("--ss-framework", type=str, choices=["mae"])
     parser.add_argument("--dataset", type=str, required=True)
+    parser.add_argument(
+        "--model-tag",
+        type=str,
+        default=None,
+        help="Canonical model tag embedded in the checkpoint filename",
+    )
+    parser.add_argument(
+        "--data-tag",
+        type=str,
+        default=None,
+        help="Canonical data tag embedded in the checkpoint filename",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed identifier to match within the checkpoint filename",
+    )
+    parser.add_argument(
+        "--best-tag",
+        type=str,
+        default=None,
+        help="Monitor tag associated with the best checkpoint selection",
+    )
     parser.add_argument("--test-pack", type=str, required=True)
     parser.add_argument("--test-split", type=str, default="test")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- add canonical checkpoint discovery logic that scans checkpoints/** using the canonical filename regex and filters via CLI tags
- extend the evaluation CLI with canonical tag selectors while keeping legacy checkpoints as a fallback
- load and validate threshold metadata from thresholds/<subdir>/<model_tag>.json and merge the stored thresholds into evaluation

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68cc668ff5e0832e8e738903afc39de5