### PR TITLE
Ensure per-rank determinism in classification training

### DIFF
--- a/src/ssl4polyp/classification/train_classification.py
+++ b/src/ssl4polyp/classification/train_classification.py
@@ -1086,6 +1086,9 @@ def train(rank, args):
 
     print(f"Rank {rank + 1}/{args.world_size} process initialized.\n")
 
+    seed = int(getattr(args, "seed", 0)) + int(rank)
+    set_determinism(seed)
+
     if rank == 0:
         os.makedirs(args.output_dir, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- seed each spawned training rank by invoking set_determinism() with a per-rank offset
- ensure deterministic cuDNN settings are configured inside the worker processes

## Testing
- python -m compileall src/ssl4polyp/classification/train_classification.py
- Not run (requires multi-GPU hardware unavailable in container): reproducibility experiment

------
https://chatgpt.com/codex/tasks/task_e_68cc78ef5de8832eb79a87f41f2a2dcc