### PR TITLE
Add multi-seed defaults to base experiment config

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -12,6 +12,7 @@ early_stop:
   patience: 10
 threshold_policy: youden
 seed: 47
+seeds: [13, 29, 47]
 image_size: 224
 num_workers: 8
 prefetch_factor: 2


### PR DESCRIPTION
## Summary
- add the multi-seed list `[13, 29, 47]` to the shared base experiment configuration so layered configs expose all three seeds

## Testing
- `PYTHONPATH=src scripts/run_exps.sh config/exp` *(fails: ModuleNotFoundError: No module named 'yaml' without optional dependencies and dataset assets in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc79c65ce4832eb0617cca0054a8c1