### PR TITLE
Set exp5c to run for 50 epochs

### DIFF
--- a/config/exp/exp5c.yaml
+++ b/config/exp/exp5c.yaml
@@ -16,3 +16,4 @@ protocol:
   thresholds:
     primary: sun_val_youden
     sensitivity: fewshot_val_youden
+epochs: 50


### PR DESCRIPTION
## Summary
- set the exp5c experiment configuration to train for 50 epochs

## Testing
- python - <<'PY'
import sys
from unittest import mock
sys.path.insert(0, "src/ssl4polyp/models/mae")
sys.path.insert(0, "src")
sys.argv = [
    "train",
    "--exp-config",
    "exp/exp5c",
    "--model-key",
    "sup_imnet",
    "--roots",
    "data/roots.example.json",
    "--output-dir",
    "outputs/confirm_exp5c",
]
import ssl4polyp.classification.train_classification as tc

def fake_spawn(fn, nprocs, args, join=True):
    print(f"Start training for {args[0].epochs} epochs")

with mock.patch.object(tc, "set_determinism", lambda seed: None), \
     mock.patch("torch.cuda.device_count", return_value=1), \
     mock.patch.object(tc.mp, "spawn", side_effect=fake_spawn):
    tc.main()
PY

------
https://chatgpt.com/codex/tasks/task_e_68ccff1728e8832ea5a517dca2dfa7b1