### PR TITLE
Add configurable fine-tuning modes and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ python -m ssl4polyp.classification.train_classification \
 * Replace `[data-root]` with path to the chosen dataset.
 * Replace `[batch-size]` with desired batch size.
 
+The degree of encoder fine-tuning can be controlled with `--finetune-mode` (or
+the `protocol.finetune` key when using experiment manifests):
+
+* `full` (default) trains the entire encoder.
+* `none` trains only the classification head, keeping the encoder frozen as in
+  prior releases.
+* `head+2` updates the head together with the final two transformer blocks for a
+  lightweight adaptation regime.
+
 The script expects the HyperKvasir directory structure by default. For datasets
 organised more simply as `data-root/class_x/*.jpg`, either pass `--simple-dataset`
 or point `--data-root` to the top-level directory and the script will infer this

--- a/src/ssl4polyp/classification/finetune.py
+++ b/src/ssl4polyp/classification/finetune.py
@@ -1,0 +1,63 @@
+from typing import Any
+
+import torch.nn as nn
+
+__all__ = [
+    "normalise_finetune_mode",
+    "configure_finetune_parameters",
+]
+
+
+def normalise_finetune_mode(raw: Any, *, default: str = "full") -> str:
+    """Resolve a user-specified fine-tuning regime into a canonical label."""
+
+    valid_modes = {"none", "full", "head+2"}
+
+    if raw is None:
+        mode = str(default).strip().lower()
+    else:
+        mode = str(raw).strip().lower()
+    if not mode:
+        mode = str(default).strip().lower()
+
+    if mode not in valid_modes:
+        raise ValueError(
+            f"Unsupported fine-tuning mode '{raw}'. Expected one of {sorted(valid_modes)}."
+        )
+
+    return mode
+
+
+def configure_finetune_parameters(model: nn.Module, mode: str) -> None:
+    """Toggle ``requires_grad`` flags according to the desired fine-tuning regime."""
+
+    resolved_mode = normalise_finetune_mode(mode, default="full")
+
+    if resolved_mode == "full":
+        for param in model.parameters():
+            param.requires_grad_(True)
+    else:
+        for param in model.parameters():
+            param.requires_grad_(False)
+
+        head_modules: list[nn.Module] = []
+        lin_head = getattr(model, "lin_head", None)
+        if isinstance(lin_head, nn.Module):
+            head_modules.append(lin_head)
+        head_module = getattr(model, "head", None)
+        if isinstance(head_module, nn.Module) and head_module is not lin_head:
+            head_modules.append(head_module)
+
+        for head in head_modules:
+            for param in head.parameters():
+                param.requires_grad_(True)
+
+        if resolved_mode == "head+2":
+            blocks = getattr(model, "blocks", None)
+            if isinstance(blocks, (nn.ModuleList, list, tuple)) and len(blocks) > 0:
+                for block in list(blocks)[-2:]:
+                    for param in block.parameters():
+                        param.requires_grad_(True)
+
+    if hasattr(model, "frozen"):
+        model.frozen = resolved_mode == "none"

--- a/src/ssl4polyp/models/models.py
+++ b/src/ssl4polyp/models/models.py
@@ -57,11 +57,7 @@ class VisionTransformer_from_Any(VisionTransformer):
         return z if self.dense else self.norm(x)
 
     def forward(self, x):
-        if self.frozen:
-            with torch.no_grad():
-                x = self.forward_features(x)
-        else:
-            x = self.forward_features(x)
+        x = self.forward_features(x)
         if self.dense:
             x = self.decoder(x)
         else:
@@ -143,11 +139,7 @@ class ViT_from_MAE(models_mae.MaskedAutoencoderViT):
         return z if self.dense else self.norm(x)
 
     def forward(self, imgs):
-        if self.frozen:
-            with torch.no_grad():
-                x = self.forward_encoder(imgs)
-        else:
-            x = self.forward_encoder(imgs)
+        x = self.forward_encoder(imgs)
         if self.dense:
             x = self.decoder(x)
         else:

--- a/tests/test_finetune_modes.py
+++ b/tests/test_finetune_modes.py
@@ -1,0 +1,58 @@
+import torch.nn as nn
+
+from ssl4polyp.classification.finetune import configure_finetune_parameters
+
+
+class DummyBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4)
+
+
+class DummyModel(nn.Module):
+    def __init__(self, depth: int):
+        super().__init__()
+        self.blocks = nn.ModuleList(DummyBlock() for _ in range(depth))
+        self.lin_head = nn.Linear(4, 3)
+        self.frozen = False
+
+
+def _trainable_parameter_names(model: nn.Module) -> set[str]:
+    return {name for name, param in model.named_parameters() if param.requires_grad}
+
+
+def _head_parameter_names(model: DummyModel) -> set[str]:
+    return {f"lin_head.{name}" for name, _ in model.lin_head.named_parameters()}
+
+
+def test_configure_finetune_mode_full_enables_all_params():
+    model = DummyModel(depth=4)
+    configure_finetune_parameters(model, "full")
+
+    assert all(param.requires_grad for param in model.parameters())
+    assert model.frozen is False
+
+
+def test_configure_finetune_mode_none_only_trains_head():
+    model = DummyModel(depth=4)
+    configure_finetune_parameters(model, "none")
+
+    trainable = _trainable_parameter_names(model)
+    assert trainable == _head_parameter_names(model)
+    assert model.frozen is True
+
+
+def test_configure_finetune_mode_head_plus_two_keeps_final_blocks():
+    depth = 6
+    model = DummyModel(depth=depth)
+    configure_finetune_parameters(model, "head+2")
+
+    trainable = _trainable_parameter_names(model)
+    expected = set(_head_parameter_names(model))
+    for idx in range(depth - 2, depth):
+        block = model.blocks[idx]
+        for name, _ in block.named_parameters():
+            expected.add(f"blocks.{idx}.{name}")
+
+    assert trainable == expected
+    assert model.frozen is False


### PR DESCRIPTION
## Summary
- add utilities to normalise fine-tuning modes and surface the setting via CLI/experiment configs
- rely on per-parameter `requires_grad` flags, including new "head+2" support, and document the regimes in the README
- add regression tests covering each fine-tuning mode

## Testing
- PYTHONPATH=src pytest tests/test_finetune_modes.py

------
https://chatgpt.com/codex/tasks/task_e_68cd17c71170832ea4c02244dc6c848f