### PR TITLE
Validate manifest schema columns and split values

### DIFF
--- a/src/ssl4polyp/configs/manifests.py
+++ b/src/ssl4polyp/configs/manifests.py
@@ -38,6 +38,7 @@ Meta = List[Row]
 SplitReturn = Tuple[Paths, Labels, Meta]
 
 REQUIRED_COLUMNS = {"frame_path", "label"}
+CANONICAL_SPLIT_NAMES = {"train", "val", "test", "eval"}
 
 
 def resolve_manifest_path(manifest: Optional[str | Path]) -> Optional[Path]:
@@ -56,20 +57,60 @@ def resolve_pack_asset(path: Optional[str | Path]) -> Optional[Path]:
     return resolve_data_pack_path(path)
 
 
-def load_split(csv_path: Path) -> Meta:
+def load_split(
+    csv_path: Path,
+    required_columns: Optional[Sequence[str]] = None,
+    split_column: Optional[str] = None,
+    expected_split_value: Optional[str] = None,
+) -> Meta:
     """Read a CSV split file and return its rows.
 
-    The CSV must contain at least the columns listed in ``REQUIRED_COLUMNS``.
-    A :class:`ValueError` is raised if any are missing.
+    Parameters
+    ----------
+    csv_path:
+        Path to the CSV file to read.
+    required_columns:
+        Additional columns expected to be present in the CSV, beyond
+        :data:`REQUIRED_COLUMNS`.
+    split_column:
+        Name of the column that encodes the logical split of the row.  When
+        provided together with ``expected_split_value`` every row must report
+        the expected value.
+    expected_split_value:
+        Expected value for ``split_column``.  A :class:`ValueError` is raised if
+        any row disagrees.
+
+    Returns
+    -------
+    Meta
+        Parsed CSV rows.
+
+    Raises
+    ------
+    ValueError
+        If any required columns are missing or if the split column contains an
+        unexpected value.
     """
 
     with open(csv_path, newline="") as f:
         reader = csv.DictReader(f)
         fieldnames = set(reader.fieldnames or [])
-        missing = REQUIRED_COLUMNS - fieldnames
+        required = set(REQUIRED_COLUMNS)
+        if required_columns is not None:
+            required.update(required_columns)
+        missing = required - fieldnames
         if missing:
             raise ValueError(f"Missing required columns {sorted(missing)} in {csv_path}")
         rows: Meta = list(reader)
+    if split_column and expected_split_value is not None:
+        for idx, row in enumerate(rows, start=1):
+            value = row.get(split_column)
+            if value != expected_split_value:
+                raise ValueError(
+                    "Split value mismatch in {} row {}: expected {!r} in column {!r}, got {!r}".format(
+                        csv_path, idx, expected_split_value, split_column, value
+                    )
+                )
     return rows
 
 
@@ -192,6 +233,8 @@ def load_pack(
     }
 
     manifest: Optional[Mapping[str, object]] = None
+    schema_columns: Optional[Sequence[str]] = None
+    split_column_name: Optional[str] = None
     if manifest_yaml is not None and not isinstance(manifest_yaml, Path):
         manifest_yaml = Path(manifest_yaml)
     pack_root = pack_root or data_packs_root()
@@ -199,6 +242,21 @@ def load_pack(
     if manifest_yaml is not None:
         with open(manifest_yaml, "r") as f:
             manifest = yaml.safe_load(f) or {}
+        if isinstance(manifest, Mapping):
+            row_schema = manifest.get("row_schema")
+            if isinstance(row_schema, Mapping):
+                fields = row_schema.get("fields")
+                if isinstance(fields, Sequence):
+                    collected = []
+                    for field in fields:
+                        if isinstance(field, Mapping):
+                            name = field.get("name")
+                            if isinstance(name, str):
+                                collected.append(name)
+                                if name == "split":
+                                    split_column_name = name
+                    if collected:
+                        schema_columns = collected
         for name in splits:
             if splits[name] is None and name in manifest:
                 entry = manifest[name]
@@ -241,7 +299,15 @@ def load_pack(
         csv_path = Path(csv_path)
         csv_path = _resolve_csv_path(csv_path)
         verify_hash(csv_path, manifest_yaml)
-        rows = load_split(csv_path)
+        expected_split_value: Optional[str] = None
+        if split_column_name is not None and name in CANONICAL_SPLIT_NAMES:
+            expected_split_value = name
+        rows = load_split(
+            csv_path,
+            required_columns=schema_columns,
+            split_column=split_column_name,
+            expected_split_value=expected_split_value,
+        )
         paths = resolve_paths(rows, roots_map)
         labels: Labels = [row.get("label", "") for row in rows]
         result[name] = (paths, labels, rows)

--- a/tests/test_manifest_schema_validation.py
+++ b/tests/test_manifest_schema_validation.py
@@ -1,0 +1,150 @@
+import csv
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+if "torch" not in sys.modules:  # pragma: no cover - test shim for environments without torch
+    sys.modules["torch"] = SimpleNamespace(
+        cuda=SimpleNamespace(
+            is_available=lambda: False,
+            device_count=lambda: 0,
+            get_device_name=lambda idx: "cpu",
+        ),
+        version=SimpleNamespace(cuda=None),
+    )
+
+if "yaml" not in sys.modules:  # pragma: no cover - test shim for environments without PyYAML
+    def _safe_load(data):
+        if hasattr(data, "read"):
+            data = data.read()
+        if not data:
+            return {}
+        return json.loads(data)
+
+    def _safe_dump(obj, stream=None):
+        serialized = json.dumps(obj)
+        if stream is None:
+            return serialized
+        stream.write(serialized)
+
+    sys.modules["yaml"] = SimpleNamespace(safe_load=_safe_load, safe_dump=_safe_dump)
+
+from ssl4polyp.configs.manifests import load_pack
+
+
+def _write_manifest(
+    path: Path,
+    fields: list[str],
+    splits: dict[str, str],
+    roots: dict[str, Path],
+) -> None:
+    manifest: dict[str, object] = {
+        "row_schema": {"fields": [{"name": name} for name in fields]},
+        "roots": {key: str(value) for key, value in roots.items()},
+    }
+    manifest.update({split: {"csv": csv_name} for split, csv_name in splits.items()})
+    path.write_text(json.dumps(manifest))
+
+
+@pytest.fixture
+def root_with_frame(tmp_path: Path) -> Path:
+    root_dir = tmp_path / "root"
+    root_dir.mkdir()
+    (root_dir / "frame.png").write_text("data")
+    return root_dir
+
+
+def test_load_pack_enforces_schema_columns(tmp_path: Path, root_with_frame: Path) -> None:
+    train_csv = tmp_path / "train.csv"
+    with open(train_csv, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["frame_path", "label", "split", "dataset"]
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "frame_path": "root/frame.png",
+                "label": "0",
+                "split": "train",
+                "dataset": "demo",
+            }
+        )
+
+    manifest_yaml = tmp_path / "manifest.yaml"
+    _write_manifest(
+        manifest_yaml,
+        fields=["frame_path", "label", "split", "dataset"],
+        splits={"train": "train.csv"},
+        roots={"root": root_with_frame},
+    )
+
+    pack = load_pack(train=train_csv, manifest_yaml=manifest_yaml)
+    paths, labels, meta = pack["train"]
+    assert labels == ["0"]
+    assert paths[0].name == "frame.png"
+    assert meta[0]["split"] == "train"
+
+
+def test_load_pack_raises_on_missing_schema_column(
+    tmp_path: Path, root_with_frame: Path
+) -> None:
+    train_csv = tmp_path / "train.csv"
+    with open(train_csv, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["frame_path", "label", "split"])
+        writer.writeheader()
+        writer.writerow(
+            {
+                "frame_path": "root/frame.png",
+                "label": "0",
+                "split": "train",
+            }
+        )
+
+    manifest_yaml = tmp_path / "manifest.yaml"
+    _write_manifest(
+        manifest_yaml,
+        fields=["frame_path", "label", "split", "dataset"],
+        splits={"train": "train.csv"},
+        roots={"root": root_with_frame},
+    )
+
+    with pytest.raises(ValueError, match="dataset"):
+        load_pack(train=train_csv, manifest_yaml=manifest_yaml)
+
+
+def test_load_pack_rejects_split_leak(tmp_path: Path, root_with_frame: Path) -> None:
+    val_csv = tmp_path / "val.csv"
+    with open(val_csv, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["frame_path", "label", "split", "dataset"]
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "frame_path": "root/frame.png",
+                "label": "0",
+                "split": "train",  # Incorrect split value
+                "dataset": "demo",
+            }
+        )
+
+    manifest_yaml = tmp_path / "manifest.yaml"
+    _write_manifest(
+        manifest_yaml,
+        fields=["frame_path", "label", "split", "dataset"],
+        splits={"val": "val.csv"},
+        roots={"root": root_with_frame},
+    )
+
+    with pytest.raises(ValueError, match="Split value mismatch"):
+        load_pack(val=val_csv, manifest_yaml=manifest_yaml)
+


### PR DESCRIPTION
## Summary
- enforce manifest-declared columns when loading dataset splits by parsing `row_schema.fields`
- reject CSV rows whose split values do not match the logical split being loaded
- add regression tests that cover successful loading as well as missing-column and split-leak failures

## Testing
- pytest tests/test_manifest_schema_validation.py


------
https://chatgpt.com/codex/tasks/task_e_68cd1fe04040832ea41fd828b3e7acaa