### PR TITLE
Fix MAE positional embedding import

### DIFF
--- a/src/ssl4polyp/models/mae/models_mae.py
+++ b/src/ssl4polyp/models/mae/models_mae.py
@@ -16,7 +16,7 @@ import torch.nn as nn
 
 from timm.models.vision_transformer import PatchEmbed, Block
 
-from util.pos_embed import get_2d_sincos_pos_embed
+from .util.pos_embed import get_2d_sincos_pos_embed
 
 
 class MaskedAutoencoderViT(nn.Module):


### PR DESCRIPTION
## Summary
- switch the MAE positional embedding import to use the package-relative path so it resolves inside the installed ssl4polyp package

## Testing
- none (import fix only)


------
https://chatgpt.com/codex/tasks/task_e_68ce5c9f5e20832e94006045a8ae7272