### PR TITLE
Print CUDA availability before launching classification experiments

### DIFF
--- a/scripts/run_exp1.sh
+++ b/scripts/run_exp1.sh
@@ -7,6 +7,18 @@ OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 SEEDS=${SEEDS:-42 47 13}
 MODELS=${MODELS:-sup_imnet ssl_imnet}
 
+python - <<'PY'
+import torch
+
+if torch.cuda.is_available():
+    count = torch.cuda.device_count()
+    names = [torch.cuda.get_device_name(i) for i in range(count)]
+    devices = ", ".join(names)
+    print(f"Detected {count} CUDA device(s): {devices}")
+else:
+    print("No CUDA devices detected; training will run on CPU.")
+PY
+
 for seed in ${SEEDS}; do
   for model in ${MODELS}; do
     out_dir="${OUTPUT_ROOT}/exp1_${model}_seed${seed}"

--- a/scripts/run_exp2.sh
+++ b/scripts/run_exp2.sh
@@ -7,6 +7,18 @@ OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 SEEDS=${SEEDS:-42 47 13}
 MODELS=${MODELS:-ssl_imnet ssl_colon}
 
+python - <<'PY'
+import torch
+
+if torch.cuda.is_available():
+    count = torch.cuda.device_count()
+    names = [torch.cuda.get_device_name(i) for i in range(count)]
+    devices = ", ".join(names)
+    print(f"Detected {count} CUDA device(s): {devices}")
+else:
+    print("No CUDA devices detected; training will run on CPU.")
+PY
+
 for seed in ${SEEDS}; do
   for model in ${MODELS}; do
     out_dir="${OUTPUT_ROOT}/exp2_${model}_seed${seed}"

--- a/scripts/run_exp3.sh
+++ b/scripts/run_exp3.sh
@@ -7,6 +7,18 @@ OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 SEEDS=${SEEDS:-42 47 13}
 MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
 
+python - <<'PY'
+import torch
+
+if torch.cuda.is_available():
+    count = torch.cuda.device_count()
+    names = [torch.cuda.get_device_name(i) for i in range(count)]
+    devices = ", ".join(names)
+    print(f"Detected {count} CUDA device(s): {devices}")
+else:
+    print("No CUDA devices detected; training will run on CPU.")
+PY
+
 for seed in ${SEEDS}; do
   for model in ${MODELS}; do
     out_dir="${OUTPUT_ROOT}/exp3_${model}_seed${seed}"

--- a/scripts/run_exp4.sh
+++ b/scripts/run_exp4.sh
@@ -8,6 +8,18 @@ SEEDS=${SEEDS:-13 29 47}
 PERCENTS=${PERCENTS:-5 10 25 50 100}
 MODEL=${MODEL:-ssl_imnet}
 
+python - <<'PY'
+import torch
+
+if torch.cuda.is_available():
+    count = torch.cuda.device_count()
+    names = [torch.cuda.get_device_name(i) for i in range(count)]
+    devices = ", ".join(names)
+    print(f"Detected {count} CUDA device(s): {devices}")
+else:
+    print("No CUDA devices detected; training will run on CPU.")
+PY
+
 for seed in ${SEEDS}; do
   for pct in ${PERCENTS}; do
     out_dir="${OUTPUT_ROOT}/exp4_${MODEL}_seed${seed}_p${pct}"

--- a/scripts/run_exp5a.sh
+++ b/scripts/run_exp5a.sh
@@ -7,6 +7,18 @@ OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 SEEDS=${SEEDS:-42 47 13}
 MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
 
+python - <<'PY'
+import torch
+
+if torch.cuda.is_available():
+    count = torch.cuda.device_count()
+    names = [torch.cuda.get_device_name(i) for i in range(count)]
+    devices = ", ".join(names)
+    print(f"Detected {count} CUDA device(s): {devices}")
+else:
+    print("No CUDA devices detected; training will run on CPU.")
+PY
+
 for seed in ${SEEDS}; do
   for model in ${MODELS}; do
     out_dir="${OUTPUT_ROOT}/exp5a_${model}_seed${seed}"

--- a/scripts/run_exp5b.sh
+++ b/scripts/run_exp5b.sh
@@ -7,6 +7,18 @@ OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 SEEDS=${SEEDS:-42 47 13}
 MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
 
+python - <<'PY'
+import torch
+
+if torch.cuda.is_available():
+    count = torch.cuda.device_count()
+    names = [torch.cuda.get_device_name(i) for i in range(count)]
+    devices = ", ".join(names)
+    print(f"Detected {count} CUDA device(s): {devices}")
+else:
+    print("No CUDA devices detected; training will run on CPU.")
+PY
+
 for seed in ${SEEDS}; do
   for model in ${MODELS}; do
     out_dir="${OUTPUT_ROOT}/exp5b_${model}_seed${seed}"

--- a/scripts/run_exp5c.sh
+++ b/scripts/run_exp5c.sh
@@ -8,6 +8,18 @@ SEEDS=${SEEDS:-13 29 47}
 SIZES=${SIZES:-50 100 200 500}
 MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
 
+python - <<'PY'
+import torch
+
+if torch.cuda.is_available():
+    count = torch.cuda.device_count()
+    names = [torch.cuda.get_device_name(i) for i in range(count)]
+    devices = ", ".join(names)
+    print(f"Detected {count} CUDA device(s): {devices}")
+else:
+    print("No CUDA devices detected; training will run on CPU.")
+PY
+
 for seed in ${SEEDS}; do
   for size in ${SIZES}; do
     for model in ${MODELS}; do

--- a/scripts/run_exps.sh
+++ b/scripts/run_exps.sh
@@ -52,6 +52,18 @@ if [[ ${#EXP_CONFIGS[@]} -eq 0 ]]; then
   exit 1
 fi
 
+python - <<'PY'
+import torch
+
+if torch.cuda.is_available():
+    count = torch.cuda.device_count()
+    names = [torch.cuda.get_device_name(i) for i in range(count)]
+    devices = ", ".join(names)
+    print(f"Detected {count} CUDA device(s): {devices}")
+else:
+    print("No CUDA devices detected; training will run on CPU.")
+PY
+
 for CONFIG_PATH in "${EXP_CONFIGS[@]}"; do
   EXP_NAME=$(basename "${CONFIG_PATH%.*}")
   echo "Launching experiment ${EXP_NAME}"


### PR DESCRIPTION
## Summary
- add a short Python check in each individual experiment launcher script to print detected CUDA devices before iterating over seeds and models
- add the same CUDA availability message to the multi-experiment `run_exps.sh` helper so it reports GPU visibility once before launching runs

## Testing
- not run (bash script change only)


------
https://chatgpt.com/codex/tasks/task_e_68d56e72e9cc832e88b39c4dcc03786b