### PR TITLE
Add TensorBoard helper with graceful fallback

### DIFF
--- a/src/ssl4polyp/classification/train_classification.py
+++ b/src/ssl4polyp/classification/train_classification.py
@@ -21,7 +21,7 @@ import torch.nn as nn
 import torch.distributed as dist
 import torch.multiprocessing as mp
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.utils.tensorboard import SummaryWriter
+from ssl4polyp.utils.tensorboard import SummaryWriter
 
 from ssl4polyp import utils
 from ssl4polyp.classification.data import create_classification_dataloaders

--- a/src/ssl4polyp/models/mae/main_finetune.py
+++ b/src/ssl4polyp/models/mae/main_finetune.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import torch
 import torch.backends.cudnn as cudnn
-from torch.utils.tensorboard import SummaryWriter
+from ssl4polyp.utils.tensorboard import SummaryWriter
 
 import timm
 

--- a/src/ssl4polyp/models/mae/main_linprobe.py
+++ b/src/ssl4polyp/models/mae/main_linprobe.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import torch
 import torch.backends.cudnn as cudnn
-from torch.utils.tensorboard import SummaryWriter
+from ssl4polyp.utils.tensorboard import SummaryWriter
 import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 

--- a/src/ssl4polyp/models/mae/main_pretrain.py
+++ b/src/ssl4polyp/models/mae/main_pretrain.py
@@ -21,7 +21,7 @@ import signal
 
 import torch
 import torch.backends.cudnn as cudnn
-from torch.utils.tensorboard import SummaryWriter
+from ssl4polyp.utils.tensorboard import SummaryWriter
 import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 

--- a/src/ssl4polyp/utils/tensorboard.py
+++ b/src/ssl4polyp/utils/tensorboard.py
@@ -1,0 +1,58 @@
+"""Utilities for working with TensorBoard writers.
+
+This module centralises the import of :class:`SummaryWriter` so the rest of
+the codebase can depend on a single location. If TensorBoard is unavailable we
+provide a lightweight stand-in that preserves the small subset of the API used
+throughout the project. This allows training scripts to continue to run while
+emitting a clear warning to install TensorBoard for logging support.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+try:  # pragma: no cover - thin wrapper over PyTorch import
+    from torch.utils.tensorboard import SummaryWriter as _TorchSummaryWriter
+except (ImportError, AttributeError) as exc:  # pragma: no cover - import guard
+    _TorchSummaryWriter = None
+    _import_exception = exc
+else:  # pragma: no cover - simple alias path
+    _import_exception = None
+
+
+class _NoOpSummaryWriter:
+    """Fallback SummaryWriter implementation.
+
+    The training scripts only rely on ``add_scalar``, ``flush`` and ``close``.
+    Each method is implemented as a no-op so the rest of the code can proceed
+    without TensorBoard. A warning is emitted once to alert the user that
+    installing TensorBoard will enable logging output.
+    """
+
+    _warned: bool = False
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        if not self.__class__._warned:
+            message = (
+                "TensorBoard SummaryWriter could not be imported. "
+                "Install TensorBoard to enable logging output. Original error: "
+                f"{_import_exception}"
+            )
+            warnings.warn(message, RuntimeWarning, stacklevel=2)
+            self.__class__._warned = True
+
+    def add_scalar(self, *args: Any, **kwargs: Any) -> None:
+        """No-op replacement for :meth:`SummaryWriter.add_scalar`."""
+
+    def flush(self) -> None:
+        """No-op replacement for :meth:`SummaryWriter.flush`."""
+
+    def close(self) -> None:
+        """No-op replacement for :meth:`SummaryWriter.close`."""
+
+
+SummaryWriter = _TorchSummaryWriter or _NoOpSummaryWriter
+
+__all__ = ["SummaryWriter"]
+


### PR DESCRIPTION
## Summary
- add a utility module that wraps SummaryWriter and provides a no-op fallback when TensorBoard is unavailable
- switch training entrypoints to import SummaryWriter from the new helper

## Testing
- python -m compileall src/ssl4polyp/utils/tensorboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d5a5a84904832e85cc410534bf99c4