### PR TITLE
Handle missing or incompatible CUDA setup in run_exp1

### DIFF
--- a/scripts/run_exp1.sh
+++ b/scripts/run_exp1.sh
@@ -8,15 +8,24 @@ SEEDS=${SEEDS:-42 47 13}
 MODELS=${MODELS:-sup_imnet ssl_imnet}
 
 python - <<'PY'
-import torch
-
-if torch.cuda.is_available():
-    count = torch.cuda.device_count()
-    names = [torch.cuda.get_device_name(i) for i in range(count)]
-    devices = ", ".join(names)
-    print(f"Detected {count} CUDA device(s): {devices}")
+try:
+    import torch
+except ModuleNotFoundError:
+    print("PyTorch not installed; skipping CUDA availability check.")
 else:
-    print("No CUDA devices detected; training will run on CPU.")
+    try:
+        if torch.cuda.is_available():
+            count = torch.cuda.device_count()
+            try:
+                names = [torch.cuda.get_device_name(i) for i in range(count)]
+                devices = ", ".join(names)
+            except RuntimeError:
+                devices = "unknown CUDA device(s)"
+            print(f"Detected {count} CUDA device(s): {devices}")
+        else:
+            print("No CUDA devices detected; training will run on CPU.")
+    except RuntimeError as err:
+        print(f"CUDA initialization failed ({err}); training will run on CPU.")
 PY
 
 for seed in ${SEEDS}; do


### PR DESCRIPTION
## Summary
- guard the CUDA detection helper in `scripts/run_exp1.sh` so the script still runs when PyTorch is unavailable or CUDA initialization fails
- report clearer messages when PyTorch is missing or CUDA cannot start, falling back to CPU execution

## Testing
- not run (environment lacks project dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68d5b24f9e60832e9801ca5554b636eb