### PR TITLE
Fallback to dataset roots when resolving manifest paths

### DIFF
--- a/src/ssl4polyp/configs/manifests.py
+++ b/src/ssl4polyp/configs/manifests.py
@@ -310,8 +310,18 @@ def resolve_paths(
         p = Path(raw)
         if roots_map and p.parts:
             root = p.parts[0]
-            if root in roots_map:
-                p = Path(roots_map[root]) / Path(*p.parts[1:])
+            mapped_root = roots_map.get(root)
+            if mapped_root is not None:
+                p = Path(mapped_root) / Path(*p.parts[1:])
+            else:
+                for key in ("store_id", "dataset"):
+                    dataset_id = row.get(key)
+                    if not dataset_id:
+                        continue
+                    dataset_root = roots_map.get(dataset_id)
+                    if dataset_root is not None:
+                        p = Path(dataset_root) / p
+                        break
         paths.append(p)
 
     if paths:


### PR DESCRIPTION
## Summary
- extend manifest path resolution to fall back to dataset identifiers when the path root is missing
- add coverage ensuring load_pack resolves dataset-rooted frame paths without raising

## Testing
- pytest tests/test_manifest_schema_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68d640258608832e801586db72075150