### PR TITLE
Add deterministic helper and reuse it across training scripts

### DIFF
--- a/src/ssl4polyp/classification/train_classification.py
+++ b/src/ssl4polyp/classification/train_classification.py
@@ -82,7 +82,7 @@ def set_determinism(seed: int) -> None:
         torch.cuda.manual_seed_all(seed)
         torch.backends.cudnn.benchmark = False
         torch.backends.cudnn.deterministic = True
-    torch.use_deterministic_algorithms(True, warn_only=True)
+    utils.enable_deterministic_algorithms()
     print(f"Setting deterministic mode with seed {seed}")
 
 

--- a/src/ssl4polyp/models/mae/main_finetune.py
+++ b/src/ssl4polyp/models/mae/main_finetune.py
@@ -21,6 +21,8 @@ import torch
 import torch.backends.cudnn as cudnn
 from ssl4polyp.utils.tensorboard import SummaryWriter
 
+from ssl4polyp import utils
+
 import timm
 
 assert timm.__version__ == "0.3.2" # version check
@@ -177,7 +179,7 @@ def main(args):
     cudnn.benchmark = False
     cudnn.deterministic = True
     # warn_only=True logs when ops fall back to non-deterministic versions
-    torch.use_deterministic_algorithms(True, warn_only=True)
+    utils.enable_deterministic_algorithms()
     use_amp = args.precision == 'amp'
 
     dataset_train = build_dataset(is_train=True, args=args)

--- a/src/ssl4polyp/models/mae/main_linprobe.py
+++ b/src/ssl4polyp/models/mae/main_linprobe.py
@@ -20,6 +20,8 @@ from pathlib import Path
 import torch
 import torch.backends.cudnn as cudnn
 from ssl4polyp.utils.tensorboard import SummaryWriter
+
+from ssl4polyp import utils
 import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 
@@ -135,7 +137,7 @@ def main(args):
     cudnn.benchmark = False
     cudnn.deterministic = True
     # warn_only=True logs when ops fall back to non-deterministic versions
-    torch.use_deterministic_algorithms(True, warn_only=True)
+    utils.enable_deterministic_algorithms()
     use_amp = args.precision == 'amp'
 
     # linear probe: weak augmentation

--- a/src/ssl4polyp/models/mae/main_pretrain.py
+++ b/src/ssl4polyp/models/mae/main_pretrain.py
@@ -25,6 +25,8 @@ from ssl4polyp.utils.tensorboard import SummaryWriter
 import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 
+from ssl4polyp import utils
+
 # --- compat shim: make timm==0.3.2 work with newer Torch ---
 from ssl4polyp._compat import ensure_torch_container_abcs
 
@@ -148,7 +150,7 @@ def main(args):
     cudnn.benchmark = False
     cudnn.deterministic = True
     # warn_only=True logs when ops fall back to non-deterministic versions
-    torch.use_deterministic_algorithms(True, warn_only=True)
+    utils.enable_deterministic_algorithms()
 
     # simple augmentation
     transform_train = transforms.Compose([

--- a/src/ssl4polyp/utils/__init__.py
+++ b/src/ssl4polyp/utils/__init__.py
@@ -4,9 +4,26 @@ from .tensorboard import SummaryWriter
 
 __all__ = [
     "SummaryWriter",
+    "enable_deterministic_algorithms",
     "get_MAE_backbone",
     "get_ImageNet_or_random_ViT",
 ]
+
+
+def enable_deterministic_algorithms(*, warn_only: bool = True) -> None:
+    """Enable deterministic algorithms with compatibility across torch releases.
+
+    Some versions of :func:`torch.use_deterministic_algorithms` do not support the
+    ``warn_only`` keyword argument.  The helper tries the modern signature first
+    and gracefully falls back to the older API when necessary.
+    """
+
+    import torch
+
+    try:
+        torch.use_deterministic_algorithms(True, warn_only=warn_only)
+    except TypeError:
+        torch.use_deterministic_algorithms(True)
 
 
 def get_MAE_backbone(weight_path, head, num_classes, frozen, dense, out_token="cls"):


### PR DESCRIPTION
## Summary
- add a utility helper that enables deterministic algorithms and falls back when warn_only is unsupported
- update classification and MAE entrypoints to call the shared helper instead of torch.use_deterministic_algorithms directly

## Testing
- SEEDS=42 MODELS=sup_imnet PYTHONPATH=src bash ./scripts/run_exp1.sh *(fails later because dataset assets are unavailable, after deterministic mode is configured)*
- PYTHONPATH=src python src/ssl4polyp/models/mae/main_pretrain.py --output_dir /tmp/mae_out --log_dir /tmp/mae_log --data_path data --no_train_dir --epochs 1 *(fails because timm 0.3.2 expects torch._six from older torch releases in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b13f22c4832e98c01f6ec82a55c3