### PR TITLE
Handle TensorBoard IO failures gracefully

### DIFF
--- a/src/ssl4polyp/utils/tensorboard.py
+++ b/src/ssl4polyp/utils/tensorboard.py
@@ -10,7 +10,7 @@ emitting a clear warning to install TensorBoard for logging support.
 from __future__ import annotations
 
 import warnings
-from typing import Any
+from typing import Any, Callable, Optional
 
 try:  # pragma: no cover - thin wrapper over PyTorch import
     from torch.utils.tensorboard import SummaryWriter as _TorchSummaryWriter
@@ -52,7 +52,81 @@ class _NoOpSummaryWriter:
         """No-op replacement for :meth:`SummaryWriter.close`."""
 
 
-SummaryWriter = _TorchSummaryWriter or _NoOpSummaryWriter
+class _SafeSummaryWriter:
+    """Runtime guard around the real TensorBoard SummaryWriter.
+
+    When the underlying :mod:`tensorboard` writer raises an :class:`OSError`
+    (typically caused by filesystem issues) the wrapper emits a warning,
+    closes the writer to flush any buffered events and turns into a no-op for
+    all subsequent calls. This keeps training loops running while surfacing
+    the logging failure to the user.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        if _TorchSummaryWriter is None:  # pragma: no cover - defensive guard
+            raise RuntimeError("_SafeSummaryWriter requires torch SummaryWriter")
+        self._factory: Callable[..., Any] = kwargs.pop("_factory", _TorchSummaryWriter)
+        self._writer: Optional[Any] = self._factory(*args, **kwargs)
+        self._enabled = True
+
+    # ``SummaryWriter`` implements ``__enter__``/``__exit__`` and some calling
+    # sites rely on it. Mirroring that behaviour keeps the wrapper drop-in.
+    def __enter__(self) -> "_SafeSummaryWriter":  # pragma: no cover - passthrough
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - passthrough
+        self.close()
+
+    @property
+    def enabled(self) -> bool:
+        """Return ``True`` while the underlying writer accepts new events."""
+
+        return self._enabled and self._writer is not None
+
+    def _disable(self, exc: BaseException) -> None:
+        if not self._enabled:
+            return
+        warnings.warn(
+            "TensorBoard logging disabled after failing to write events: "
+            f"{exc}",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+        if self._writer is not None:
+            try:
+                self._writer.close()
+            except Exception:  # pragma: no cover - best effort cleanup
+                pass
+        self._writer = None
+        self._enabled = False
+
+    def _call_writer(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        if not self.enabled:
+            return None
+        assert self._writer is not None  # for type checkers
+        method = getattr(self._writer, name)
+        try:
+            return method(*args, **kwargs)
+        except (OSError, IOError) as exc:
+            self._disable(exc)
+            return None
+
+    def add_scalar(self, *args: Any, **kwargs: Any) -> None:
+        self._call_writer("add_scalar", *args, **kwargs)
+
+    def flush(self) -> None:
+        self._call_writer("flush")
+
+    def close(self) -> None:
+        if self._writer is not None:
+            try:
+                self._writer.close()
+            finally:
+                self._writer = None
+        self._enabled = False
+
+
+SummaryWriter = _SafeSummaryWriter if _TorchSummaryWriter else _NoOpSummaryWriter
 
 __all__ = ["SummaryWriter"]
 

--- a/tests/test_tensorboard_logging.py
+++ b/tests/test_tensorboard_logging.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+torch = pytest.importorskip("torch")
+from torch.utils.data import DataLoader, TensorDataset
+
+from ssl4polyp.classification.train_classification import (
+    TensorboardLogger,
+    train_epoch,
+)
+
+
+class DummyScaler:
+    def scale(self, loss: torch.Tensor) -> torch.Tensor:
+        return loss
+
+    def step(self, optimizer: torch.optim.Optimizer) -> None:
+        optimizer.step()
+
+    def update(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
+class FailingWriter:
+    def __init__(self) -> None:
+        self.closed = False
+        self.calls = 0
+
+    def add_scalar(self, *args, **kwargs) -> None:
+        self.calls += 1
+        raise OSError("disk full")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _make_loader() -> DataLoader:
+    features = torch.randn(4, 8)
+    labels = torch.tensor([0, 1, 0, 1])
+    dataset = TensorDataset(features, labels)
+    return DataLoader(dataset, batch_size=2)
+
+
+def test_train_epoch_disables_tensorboard_on_failure(tmp_path) -> None:
+    model = torch.nn.Linear(8, 2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    loss_fn = torch.nn.CrossEntropyLoss()
+    scaler = DummyScaler()
+    loader = _make_loader()
+    failing_writer = FailingWriter()
+    tb_logger = TensorboardLogger(failing_writer)
+
+    with pytest.warns(RuntimeWarning, match="TensorBoard logging"):
+        loss, global_step = train_epoch(
+            model,
+            rank=0,
+            world_size=1,
+            train_loader=loader,
+            train_sampler=None,
+            optimizer=optimizer,
+            epoch=1,
+            loss_fn=loss_fn,
+            log_path=str(tmp_path / "log.txt"),
+            scaler=scaler,
+            use_amp=False,
+            tb_logger=tb_logger,
+            log_interval=1,
+            global_step=0,
+            seed=0,
+            device=torch.device("cpu"),
+            distributed=False,
+        )
+
+    assert np.isfinite(loss)
+    assert global_step == len(loader)
+    assert failing_writer.closed
+    assert not tb_logger


### PR DESCRIPTION
## Summary
- wrap the PyTorch SummaryWriter in a safe adapter that disables itself after IO failures
- centralize classification TensorBoard usage behind a helper that tolerates disabled logging
- add a regression test that exercises training when TensorBoard logging raises an OSError

## Testing
- pytest tests/test_tensorboard_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68da563044d0832ea0aaf25080d2810f