### PR TITLE
Enable Exp5a SUN fine-tuning with transfer evaluations

### DIFF
--- a/config/exp/exp5a.yaml
+++ b/config/exp/exp5a.yaml
@@ -1,11 +1,18 @@
 defaults:
   - base
-  - data/polypgen_clean_test
+  - data/sun_full
 models:
   - model/sup_imnet
   - model/ssl_imnet
   - model/ssl_colon
 protocol:
-  init_from: canonical_sun_models
-  finetune: none
+  finetune: full
   eval_split: test
+  early_stop_split: val
+  thresholds: sun_val_youden
+transfer_targets:
+  polypgen_clean:
+    name: polypgen_clean_test
+    pack: polypgen_clean_test
+    test_split: test
+    stem: polypgen

--- a/scripts/run_exp5a.sh
+++ b/scripts/run_exp5a.sh
@@ -6,6 +6,7 @@ ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 SEEDS=${SEEDS:-42 47 13}
 MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
+EXP_CONFIG=${EXP_CONFIG:-exp/exp5a.yaml}
 
 python - <<'PY'
 import torch
@@ -19,14 +20,119 @@ else:
     print("No CUDA devices detected; training will run on CPU.")
 PY
 
+readarray -t TARGET_META < <(EXP_CONFIG_REF="${EXP_CONFIG}" python - <<'PY'
+import os
+from ssl4polyp.configs.layered import load_layered_config
+
+config = load_layered_config(os.environ["EXP_CONFIG_REF"])
+targets = config.get("transfer_targets") or {}
+polyp = targets.get("polypgen_clean") or {}
+name = polyp.get("name") or "polypgen_clean_test"
+pack = polyp.get("pack") or name
+split = polyp.get("test_split") or "test"
+stem = polyp.get("stem") or "polypgen"
+print(name)
+print(pack)
+print(split)
+print(stem)
+PY
+)
+
+POLYP_NAME=${TARGET_META[0]}
+POLYP_PACK=${TARGET_META[1]}
+POLYP_SPLIT=${TARGET_META[2]}
+POLYP_STEM=${TARGET_META[3]}
+
+resolve_checkpoint() {
+  local run_dir="$1"
+  python - <<'PY' "$run_dir"
+from pathlib import Path
+import sys
+
+run_dir = Path(sys.argv[1]).expanduser()
+if not run_dir.exists():
+    raise SystemExit(f"Training directory not found: {run_dir}")
+
+candidates = sorted(run_dir.rglob("*.pth"))
+if not candidates:
+    raise SystemExit(f"No checkpoints found under {run_dir}")
+
+pointer = None
+for path in candidates:
+    try:
+        relative_parts = path.relative_to(run_dir).parts[:-1]
+    except ValueError:
+        relative_parts = ()
+    if any(part.startswith("eval_") for part in relative_parts):
+        continue
+    stem = path.stem
+    if stem.endswith("_last"):
+        continue
+    if "_e" not in stem:
+        pointer = path
+        break
+if pointer is None:
+    for path in reversed(candidates):
+        try:
+            relative_parts = path.relative_to(run_dir).parts[:-1]
+        except ValueError:
+            relative_parts = ()
+        if any(part.startswith("eval_") for part in relative_parts):
+            continue
+        pointer = path
+        break
+    if pointer is None:
+        pointer = candidates[-1]
+print(pointer.resolve())
+PY
+}
+
 for seed in ${SEEDS}; do
   for model in ${MODELS}; do
-    out_dir="${OUTPUT_ROOT}/exp5a_${model}_seed${seed}"
+    base_dir="${OUTPUT_ROOT}/exp5a_${model}_seed${seed}"
     python -m ssl4polyp.classification.train_classification \
-      --exp-config exp/exp5a.yaml \
+      --exp-config "${EXP_CONFIG}" \
       --model-key "${model}" \
       --seed "${seed}" \
       --roots "${ROOTS}" \
-      --output-dir "${out_dir}" "${@}"
+      --output-dir "${base_dir}" "$@"
+
+    checkpoint_path=$(resolve_checkpoint "${base_dir}")
+
+    sun_eval_dir="${base_dir}/eval_sun"
+    python -m ssl4polyp.classification.train_classification \
+      --exp-config "${EXP_CONFIG}" \
+      --model-key "${model}" \
+      --seed "${seed}" \
+      --roots "${ROOTS}" \
+      --output-dir "${sun_eval_dir}" \
+      --parent-checkpoint "${checkpoint_path}" \
+      --finetune-mode none \
+      --frozen \
+      --override \
+        dataset.train_pack=null \
+        dataset.splits.train=null \
+        dataset.val_pack=null \
+        dataset.splits.val=null "$@"
+
+    polyp_eval_dir="${base_dir}/eval_${POLYP_STEM}"
+    python -m ssl4polyp.classification.train_classification \
+      --exp-config "${EXP_CONFIG}" \
+      --model-key "${model}" \
+      --seed "${seed}" \
+      --roots "${ROOTS}" \
+      --output-dir "${polyp_eval_dir}" \
+      --parent-checkpoint "${checkpoint_path}" \
+      --finetune-mode none \
+      --frozen \
+      --override \
+        dataset.name="${POLYP_NAME}" \
+        dataset.pack="${POLYP_PACK}" \
+        dataset.test_pack="${POLYP_PACK}" \
+        dataset.splits.test="${POLYP_SPLIT}" \
+        dataset.train_pack=null \
+        dataset.splits.train=null \
+        dataset.val_pack=null \
+        dataset.splits.val=null "$@"
   done
 done


### PR DESCRIPTION
## Summary
- update the Exp5a experiment to inherit the SUN training pack, enable full fine-tuning, and record the PolypGen transfer target metadata
- refactor the Exp5a runner to train on SUN, run an in-domain evaluation, and launch a PolypGen evaluation-only pass that reuses the SUN checkpoint
- teach `train_classification` to honour `--parent-checkpoint` by loading the supplied weights and thresholds before evaluation-only runs

## Testing
- python -m compileall src/ssl4polyp/classification/train_classification.py
- bash -n scripts/run_exp5a.sh

------
https://chatgpt.com/codex/tasks/task_e_68daf3bd4224832e890e9998c778109f