### PR TITLE
Support canonical SUN parent checkpoints for exp5a

### DIFF
--- a/scripts/run_exp5a.sh
+++ b/scripts/run_exp5a.sh
@@ -4,8 +4,16 @@ set -euo pipefail
 
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
+PARENT_ROOT=${PARENT_ROOT:-checkpoints/classification}
 SEEDS=${SEEDS:-42 47 13}
 MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
+
+# Canonical SUN fine-tuning checkpoints must be available prior to running this
+# script. The expected layout is:
+#   ${PARENT_ROOT}/exp1_sup_imnet_seed{seed}/sup_imnet__SUNFull_s{seed}.pth
+#   ${PARENT_ROOT}/exp1_ssl_imnet_seed{seed}/ssl_imnet__SUNFull_s{seed}.pth
+#   ${PARENT_ROOT}/exp2_ssl_colon_seed{seed}/ssl_colon__SUNFull_s{seed}.pth
+# for each seed used below.
 
 python - <<'PY'
 import torch
@@ -22,10 +30,30 @@ PY
 for seed in ${SEEDS}; do
   for model in ${MODELS}; do
     out_dir="${OUTPUT_ROOT}/exp5a_${model}_seed${seed}"
+    case "${model}" in
+      sup_imnet)
+        parent_rel="exp1_sup_imnet_seed${seed}/sup_imnet__SUNFull_s${seed}.pth"
+        ;;
+      ssl_imnet)
+        parent_rel="exp1_ssl_imnet_seed${seed}/ssl_imnet__SUNFull_s${seed}.pth"
+        ;;
+      ssl_colon)
+        parent_rel="exp2_ssl_colon_seed${seed}/ssl_colon__SUNFull_s${seed}.pth"
+        ;;
+      *)
+        echo "Unknown model '${model}' requested; cannot resolve parent checkpoint." >&2
+        exit 1
+        ;;
+    esac
+    parent_ckpt="${PARENT_ROOT}/${parent_rel}"
+    if [[ ! -f "${parent_ckpt}" ]]; then
+      echo "Warning: expected parent checkpoint '${parent_ckpt}' not found." >&2
+    fi
     python -m ssl4polyp.classification.train_classification \
       --exp-config exp/exp5a.yaml \
       --model-key "${model}" \
       --seed "${seed}" \
+      --parent-checkpoint "${parent_ckpt}" \
       --roots "${ROOTS}" \
       --output-dir "${out_dir}" "${@}"
   done


### PR DESCRIPTION
## Summary
- resolve canonical SUN parent checkpoints from experiment configurations and load them during model build
- enhance the exp5a runner to locate per-model parent checkpoints and pass them explicitly on invocation

## Testing
- python -m compileall src/ssl4polyp/classification/train_classification.py

------
https://chatgpt.com/codex/tasks/task_e_68dafa72ede0832eae861a5234fe8fc8