### PR TITLE
Preserve SUN evaluation thresholds in classification metrics

### DIFF
--- a/src/ssl4polyp/classification/metrics/performance.py
+++ b/src/ssl4polyp/classification/metrics/performance.py
@@ -101,10 +101,11 @@ class meanF1Score(nn.Module):
         self.n_class = n_class
         self.smooth = smooth
 
-    def forward(self, preds, targets):
+    def forward(self, preds, targets, tau: Optional[float] = None):
+        labels = _as_label_predictions(preds.detach(), self.n_class, tau)
         score = 0
         for i in range(self.n_class):
-            m1 = preds == i
+            m1 = labels == i
             m2 = targets == i
             intersection = m1 * m2
 
@@ -122,10 +123,11 @@ class meanPrecision(nn.Module):
         self.n_class = n_class
         self.smooth = smooth
 
-    def forward(self, preds, targets):
+    def forward(self, preds, targets, tau: Optional[float] = None):
+        labels = _as_label_predictions(preds.detach(), self.n_class, tau)
         score = 0
         for i in range(self.n_class):
-            m1 = preds == i
+            m1 = labels == i
             m2 = targets == i
             intersection = m1 * m2
 
@@ -139,10 +141,11 @@ class meanRecall(nn.Module):
         self.n_class = n_class
         self.smooth = smooth
 
-    def forward(self, preds, targets):
+    def forward(self, preds, targets, tau: Optional[float] = None):
+        labels = _as_label_predictions(preds.detach(), self.n_class, tau)
         score = 0
         for i in range(self.n_class):
-            m1 = preds == i
+            m1 = labels == i
             m2 = targets == i
             intersection = m1 * m2
 


### PR DESCRIPTION
## Summary
- carry forward stored thresholds when loading parent checkpoints to support evaluation-only runs
- resolve SUN validation thresholds during evaluation and pass them into test metrics so binary decisions use the SUN rule
- allow auxiliary classification metrics to consume logits with an optional threshold to keep reports consistent

## Testing
- python -m compileall src/ssl4polyp/classification

------
https://chatgpt.com/codex/tasks/task_e_68dbde67f37c832eaa652a0ed85dbfc3