### PR TITLE
Fix SUN threshold key lookup for SUN evaluations

### DIFF
--- a/src/ssl4polyp/classification/train_classification.py
+++ b/src/ssl4polyp/classification/train_classification.py
@@ -1456,7 +1456,7 @@ def train(rank, args):
         "recall": performance.meanRecall(n_class=n_classes),
     }
     sun_threshold_key = thresholds.format_threshold_key(
-        "sunfull", args.val_split or "val", "youden"
+        "sun_full", args.val_split or "val", "youden"
     )
 
     def resolve_eval_tau(*keys: Optional[str]) -> Optional[float]:


### PR DESCRIPTION
## Summary
- update the SUN threshold key construction to use the canonical `sun_full` dataset identifier so stored taus are recovered during evaluation

## Testing
- PYTHONPATH=src python -m ssl4polyp.classification.train_classification --exp-config exp/exp5a.yaml --model-key sup_imnet --seed 42 --output-dir outputs/tmp_eval --finetune-mode none --frozen *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68dbf3ea7cfc832ea23ac768c3621d6d