### PR TITLE
Align experiment launch scripts with config-defined seeds

### DIFF
--- a/scripts/print_config_seeds.py
+++ b/scripts/print_config_seeds.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Print the canonical seed list for an experiment configuration."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+for path in (SRC_ROOT, REPO_ROOT):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+try:
+    from ssl4polyp.configs.layered import load_layered_config
+except ModuleNotFoundError as exc:  # pragma: no cover - dependency issues
+    if exc.name == "ssl4polyp":
+        raise SystemExit(
+            "Unable to import 'ssl4polyp'. Ensure the repository is installed or "
+            "the PYTHONPATH includes its root before running this helper."
+        ) from exc
+    raise
+
+
+def _normalize_seeds(raw: Iterable[int | str]) -> List[int]:
+    seeds: List[int] = []
+    for item in raw:
+        if isinstance(item, int):
+            seeds.append(item)
+        elif isinstance(item, str):
+            parts = [p for p in item.replace(",", " ").split() if p]
+            seeds.extend(int(p) for p in parts)
+        else:
+            raise TypeError(f"Unsupported seed value type: {type(item)!r}")
+    return seeds
+
+
+def _extract_seeds(config: dict) -> List[int]:
+    if "seeds" in config and config["seeds"] is not None:
+        raw = config["seeds"]
+        if isinstance(raw, (int, str)):
+            return _normalize_seeds([raw])
+        return _normalize_seeds(raw)
+
+    if "seed" in config and config["seed"] is not None:
+        raw = config["seed"]
+        if isinstance(raw, Iterable) and not isinstance(raw, (str, bytes)):
+            return _normalize_seeds(raw)  # type: ignore[arg-type]
+        return _normalize_seeds([raw])
+
+    protocol = config.get("protocol", {}) or {}
+    for key in ("seeds", "subset_seeds"):
+        if key in protocol and protocol[key] is not None:
+            raw = protocol[key]
+            if isinstance(raw, (int, str)):
+                return _normalize_seeds([raw])
+            return _normalize_seeds(raw)
+
+    dataset = config.get("dataset", {}) or {}
+    for key in ("seeds", "seed"):
+        if key in dataset and dataset[key] is not None:
+            raw = dataset[key]
+            if isinstance(raw, (int, str)):
+                return _normalize_seeds([raw])
+            return _normalize_seeds(raw)
+
+    raise ValueError("Configuration does not define a seed list.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "config",
+        help=(
+            "Experiment configuration reference (e.g., 'exp/exp1.yaml'). "
+            "The path is resolved using the layered config loader."
+        ),
+    )
+    args = parser.parse_args()
+
+    cfg = load_layered_config(args.config)
+    seeds = _extract_seeds(cfg)
+    if not seeds:
+        raise SystemExit("Configuration does not define any seeds.")
+
+    print(" ".join(str(seed) for seed in seeds))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_exp1.sh
+++ b/scripts/run_exp1.sh
@@ -2,9 +2,12 @@
 
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+EXP_CONFIG=${EXP_CONFIG:-exp/exp1.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
-SEEDS=${SEEDS:-42 47 13}
+DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
 MODELS=${MODELS:-sup_imnet ssl_imnet}
 
 python - <<'PY'
@@ -32,7 +35,7 @@ for seed in ${SEEDS}; do
   for model in ${MODELS}; do
     out_dir="${OUTPUT_ROOT}/exp1_${model}_seed${seed}"
     python -m ssl4polyp.classification.train_classification \
-      --exp-config exp/exp1.yaml \
+      --exp-config "${EXP_CONFIG}" \
       --model-key "${model}" \
       --seed "${seed}" \
       --roots "${ROOTS}" \

--- a/scripts/run_exp2.sh
+++ b/scripts/run_exp2.sh
@@ -2,9 +2,12 @@
 
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+EXP_CONFIG=${EXP_CONFIG:-exp/exp2.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
-SEEDS=${SEEDS:-42 47 13}
+DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
 MODELS=${MODELS:-ssl_imnet ssl_colon}
 
 python - <<'PY'
@@ -23,7 +26,7 @@ for seed in ${SEEDS}; do
   for model in ${MODELS}; do
     out_dir="${OUTPUT_ROOT}/exp2_${model}_seed${seed}"
     python -m ssl4polyp.classification.train_classification \
-      --exp-config exp/exp2.yaml \
+      --exp-config "${EXP_CONFIG}" \
       --model-key "${model}" \
       --seed "${seed}" \
       --roots "${ROOTS}" \

--- a/scripts/run_exp3.sh
+++ b/scripts/run_exp3.sh
@@ -2,9 +2,12 @@
 
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+EXP_CONFIG=${EXP_CONFIG:-exp/exp3.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
-SEEDS=${SEEDS:-42 47 13}
+DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
 MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
 
 python - <<'PY'
@@ -23,7 +26,7 @@ for seed in ${SEEDS}; do
   for model in ${MODELS}; do
     out_dir="${OUTPUT_ROOT}/exp3_${model}_seed${seed}"
     python -m ssl4polyp.classification.train_classification \
-      --exp-config exp/exp3.yaml \
+      --exp-config "${EXP_CONFIG}" \
       --model-key "${model}" \
       --seed "${seed}" \
       --roots "${ROOTS}" \

--- a/scripts/run_exp4.sh
+++ b/scripts/run_exp4.sh
@@ -2,9 +2,12 @@
 
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+EXP_CONFIG=${EXP_CONFIG:-exp/exp4.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
-SEEDS=${SEEDS:-13 29 47}
+DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
 PERCENTS=${PERCENTS:-5 10 25 50 100}
 MODEL=${MODEL:-ssl_imnet}
 
@@ -24,7 +27,7 @@ for seed in ${SEEDS}; do
   for pct in ${PERCENTS}; do
     out_dir="${OUTPUT_ROOT}/exp4_${MODEL}_seed${seed}_p${pct}"
     python -m ssl4polyp.classification.train_classification \
-      --exp-config exp/exp4.yaml \
+      --exp-config "${EXP_CONFIG}" \
       --model-key "${MODEL}" \
       --seed "${seed}" \
       --roots "${ROOTS}" \

--- a/scripts/run_exp5a.sh
+++ b/scripts/run_exp5a.sh
@@ -2,10 +2,13 @@
 
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+EXP_CONFIG=${EXP_CONFIG:-exp/exp5a.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 PARENT_ROOT=${PARENT_ROOT:-checkpoints/classification}
-SEEDS=${SEEDS:-42 47 13}
+DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
 MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
 
 # Canonical SUN fine-tuning checkpoints must be available prior to running this
@@ -65,7 +68,7 @@ EOF
       exit 1
     fi
     python -m ssl4polyp.classification.train_classification \
-      --exp-config exp/exp5a.yaml \
+      --exp-config "${EXP_CONFIG}" \
       --model-key "${model}" \
       --seed "${seed}" \
       --parent-checkpoint "${parent_ckpt}" \

--- a/scripts/run_exp5b.sh
+++ b/scripts/run_exp5b.sh
@@ -2,9 +2,12 @@
 
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+EXP_CONFIG=${EXP_CONFIG:-exp/exp5b.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
-SEEDS=${SEEDS:-42 47 13}
+DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
 MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
 
 python - <<'PY'
@@ -23,7 +26,7 @@ for seed in ${SEEDS}; do
   for model in ${MODELS}; do
     out_dir="${OUTPUT_ROOT}/exp5b_${model}_seed${seed}"
     python -m ssl4polyp.classification.train_classification \
-      --exp-config exp/exp5b.yaml \
+      --exp-config "${EXP_CONFIG}" \
       --model-key "${model}" \
       --seed "${seed}" \
       --roots "${ROOTS}" \

--- a/scripts/run_exp5c.sh
+++ b/scripts/run_exp5c.sh
@@ -2,9 +2,12 @@
 
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+EXP_CONFIG=${EXP_CONFIG:-exp/exp5c.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
-SEEDS=${SEEDS:-13 29 47}
+DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
 SIZES=${SIZES:-50 100 200 500}
 MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
 
@@ -25,7 +28,7 @@ for seed in ${SEEDS}; do
     for model in ${MODELS}; do
       out_dir="${OUTPUT_ROOT}/exp5c_${model}_seed${seed}_s${size}"
       python -m ssl4polyp.classification.train_classification \
-        --exp-config exp/exp5c.yaml \
+        --exp-config "${EXP_CONFIG}" \
         --model-key "${model}" \
         --seed "${seed}" \
         --roots "${ROOTS}" \


### PR DESCRIPTION
## Summary
- add a helper utility to read canonical seed lists from the layered experiment configs
- update run_exp1/2/3/4/5a/5b/5c launchers to source their default seeds via the helper and respect EXP_CONFIG overrides

## Testing
- python scripts/print_config_seeds.py exp/exp1.yaml *(fails: ModuleNotFoundError: No module named 'yaml' in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc40f05b94832eb7beb4cc8a22292a