### PR TITLE
Add smoke experiment config and tests for CLI limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,27 @@ python -m ssl4polyp.classification.train_classification \
     --seed 42
 ```
 
+For quick smoke tests, `config/exp/exp1_smoke.yaml` layers the standard
+experiment with the SUN subset manifest (`config/data/sun_subsets.yaml`),
+shrinking the run to 5 % of the data, two epochs and a handful of batches per
+split by default. The CLI exposes matching knobs: `--dataset-percent` and
+`--dataset-seed` pick one of the subset packs declared in
+`config/data/sun_subsets.yaml`, while `--limit-train-batches`,
+`--limit-val-batches` and `--limit-test-batches` cap the number of batches per
+epoch. A fully constrained invocation therefore looks like:
+
+```
+python -m ssl4polyp.classification.train_classification \
+    --exp-config exp/exp1_smoke.yaml \
+    --model-key sup_imnet \
+    --dataset-percent 10 \
+    --dataset-seed 29 \
+    --limit-train-batches 2 \
+    --limit-val-batches 1 \
+    --limit-test-batches 2 \
+    --output-dir checkpoints/classification/exp1_smoke_demo
+```
+
 Choose a different `--model-key` to fine-tune the MAE variants defined in
 `config/model/*.yaml`.  You can still override individual knobs on the command
 line (for example `--batch-size` or `--lr`) and they will overwrite values from

--- a/config/exp/exp1_smoke.yaml
+++ b/config/exp/exp1_smoke.yaml
@@ -1,0 +1,12 @@
+defaults:
+  - exp1
+  - data/sun_subsets
+
+dataset:
+  percent: 5
+  seed: 13
+
+epochs: 2
+limit_train_batches: 4
+limit_val_batches: 2
+limit_test_batches: 2

--- a/src/ssl4polyp/classification/train_classification.py
+++ b/src/ssl4polyp/classification/train_classification.py
@@ -959,6 +959,14 @@ def apply_experiment_config(args, experiment_cfg: Dict[str, Any]):
         "threshold_policy", getattr(args, "threshold_policy", None)
     )
 
+    for limit_key in ("limit_train_batches", "limit_val_batches", "limit_test_batches"):
+        limit_value = experiment_cfg.get(limit_key)
+        if limit_value is None:
+            continue
+        current_value = getattr(args, limit_key, None)
+        if current_value is None:
+            setattr(args, limit_key, int(limit_value))
+
     amp_enabled = experiment_cfg.get("amp")
     if amp_enabled is not None:
         args.precision = "amp" if amp_enabled else "fp32"

--- a/tests/test_classification_eval_mode.py
+++ b/tests/test_classification_eval_mode.py
@@ -8,6 +8,13 @@ import pytest
 
 pytest.importorskip("torch")
 
+import math
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 if "distutils" not in sys.modules:
@@ -33,6 +40,7 @@ if "yaml" not in sys.modules:
 
 from ssl4polyp.classification import train_classification
 from ssl4polyp.classification.data import packs
+from ssl4polyp.configs.layered import load_layered_config
 
 
 def test_eval_only_dataset_skips_training_csv(monkeypatch, tmp_path):
@@ -101,3 +109,111 @@ def test_eval_only_dataset_skips_training_csv(monkeypatch, tmp_path):
     assert any("test" in group for group in requested_splits)
     assert all("train" not in group for group in requested_splits)
     assert datasets.get(resolved["test_split"] or "test") is not None
+
+
+def test_cli_subset_overrides_and_batch_limits(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["pytest"])
+    args = train_classification.get_args()
+    args.dataset_percent = 10.0
+    args.dataset_seed = 29
+    args.limit_train_batches = 2
+    args.limit_val_batches = 1
+    args.limit_test_batches = 3
+    args.model_key = "sup_imnet"
+    args.output_dir = str(tmp_path)
+    args.log_interval = 1
+
+    experiment_cfg = load_layered_config("exp/exp1_smoke.yaml")
+    _, dataset_cfg, dataset_resolved = train_classification.apply_experiment_config(
+        args, experiment_cfg
+    )
+
+    assert dataset_cfg["name"] == "sun_subsets"
+    assert dataset_cfg["percent"] == 10
+    assert dataset_cfg["seed"] == 29
+    assert str(dataset_resolved["train_pack"]).endswith("sun_p10_seed29")
+    assert str(args.train_pack).endswith("sun_p10_seed29")
+    assert args.limit_train_batches == 2
+    assert args.limit_val_batches == 1
+    assert args.limit_test_batches == 3
+
+    class DummyDataset:
+        def __init__(self, samples):
+            self._samples = samples
+
+        def __len__(self):
+            return self._samples
+
+    class CountingLoader:
+        def __init__(self, batches, batch_size):
+            self._batches = batches
+            self._batch_size = batch_size
+            self.dataset = DummyDataset(batches * batch_size)
+            self._yielded = 0
+
+        def __len__(self):
+            return self._batches
+
+        def __iter__(self):
+            self._yielded = 0
+            for _ in range(self._batches):
+                self._yielded += 1
+                images = torch.zeros(self._batch_size, 3, 4, 4)
+                labels = torch.zeros(self._batch_size, dtype=torch.long)
+                yield images, labels, {}
+
+        @property
+        def yielded(self):
+            return self._yielded
+
+    model = nn.Sequential(nn.Flatten(), nn.Linear(3 * 4 * 4, 2))
+    optimizer = optim.SGD(model.parameters(), lr=0.1)
+    loss_fn = nn.CrossEntropyLoss()
+    scaler = torch.cuda.amp.GradScaler(enabled=False)
+    train_loader = CountingLoader(batches=5, batch_size=2)
+    train_loss, new_step = train_classification.train_epoch(
+        model,
+        rank=0,
+        world_size=1,
+        train_loader=train_loader,
+        train_sampler=None,
+        optimizer=optimizer,
+        epoch=1,
+        loss_fn=loss_fn,
+        log_path=str(tmp_path / "train.log"),
+        scaler=scaler,
+        use_amp=False,
+        tb_logger=None,
+        log_interval=args.log_interval,
+        global_step=0,
+        seed=42,
+        device=torch.device("cpu"),
+        distributed=False,
+        max_batches=args.limit_train_batches,
+    )
+
+    assert not math.isnan(float(train_loss))
+    assert new_step == args.limit_train_batches
+    assert train_loader.yielded == args.limit_train_batches
+
+    test_loader = CountingLoader(batches=6, batch_size=2)
+
+    def dummy_perf(probs, targets):
+        return torch.tensor(0.5)
+
+    results = train_classification.test(
+        model,
+        rank=0,
+        test_loader=test_loader,
+        epoch=1,
+        perf_fn=dummy_perf,
+        log_path=str(tmp_path / "test.log"),
+        metric_fns={},
+        split_name="Test",
+        return_outputs=False,
+        tau=None,
+        max_batches=args.limit_test_batches,
+    )
+
+    assert "auroc" in results
+    assert test_loader.yielded == args.limit_test_batches


### PR DESCRIPTION
## Summary
- add an `exp1_smoke` experiment config that layers SUN subsets with short epoch and loader limits
- propagate loader limit defaults from manifests and document the new smoke-test workflow in the README
- extend the classification test suite to cover CLI dataset overrides and loader limiting behaviour

## Testing
- pytest tests/test_classification_eval_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68dcee85b124832e81fb483254ad03f1