### PR TITLE
Handle undefined AUROC cases

### DIFF
--- a/tests/test_performance_metrics.py
+++ b/tests/test_performance_metrics.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import warnings
+
 import pytest
 import torch
 from sklearn.metrics import average_precision_score, balanced_accuracy_score
 
-from ssl4polyp.classification.metrics.performance import meanAUPRC, meanBalancedAccuracy
+from ssl4polyp.classification.metrics.performance import meanAUPRC, meanAUROC, meanBalancedAccuracy
 
 
 def test_balanced_accuracy_binary_with_tau():
@@ -101,3 +103,41 @@ def test_mauprc_multiclass_probabilities():
     expected = average_precision_score(one_hot, probs.numpy(), average="macro")
 
     assert score == pytest.approx(expected)
+
+
+def test_mean_auroc_binary_single_class_returns_nan():
+    probs = torch.tensor(
+        [
+            [0.9, 0.1],
+            [0.8, 0.2],
+            [0.7, 0.3],
+        ]
+    )
+    targets = torch.tensor([0, 0, 0])
+    metric = meanAUROC(n_class=2)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        score = metric(probs, targets)
+
+    assert caught, "Expected a warning when AUROC is undefined"
+    assert torch.isnan(score).item()
+
+
+def test_mean_auroc_multiclass_single_class_returns_nan():
+    probs = torch.tensor(
+        [
+            [0.6, 0.3, 0.1],
+            [0.55, 0.25, 0.2],
+            [0.7, 0.2, 0.1],
+        ]
+    )
+    targets = torch.tensor([0, 0, 0])
+    metric = meanAUROC(n_class=3)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        score = metric(probs, targets)
+
+    assert caught, "Expected a warning when AUROC is undefined"
+    assert torch.isnan(score).item()


### PR DESCRIPTION
## Summary
- guard the meanAUROC metric against single-class targets by returning a NaN fallback and emitting a warning
- ensure the macro AUROC computation only runs when at least two classes are present and return float32 tensors on the original device
- add regression tests that verify the binary and multi-class AUROC metrics return the fallback value for single-class inputs

## Testing
- pytest tests/test_performance_metrics.py *(fails: ModuleNotFoundError: No module named 'torch')*
- bash ./scripts/run_exp1_smoke.sh *(fails: ModuleNotFoundError: No module named 'ssl4polyp')*

------
https://chatgpt.com/codex/tasks/task_e_68dd0b9e68f8832e8b8d8a27066ccead