### PR TITLE
Guard learning rate scheduler before first optimizer step

### DIFF
--- a/src/ssl4polyp/classification/train_classification.py
+++ b/src/ssl4polyp/classification/train_classification.py
@@ -1739,6 +1739,7 @@ def train(rank, args):
 
     for epoch in range(start_epoch, args.epochs + 1):
         try:
+            prev_global_step = global_step
             loss, global_step = train_epoch(
                 model,
                 rank,
@@ -1809,7 +1810,8 @@ def train(rank, args):
                 val_perf = 0.0
                 test_perf = 0.0
 
-            if scheduler is not None:
+            steps_this_epoch = global_step - prev_global_step
+            if scheduler is not None and steps_this_epoch > 0:
                 if scheduler_name == "plateau":
                     if distributed:
                         metric_tensor = torch.tensor(


### PR DESCRIPTION
## Summary
- record the global step prior to each epoch and require at least one optimizer update before advancing the scheduler

## Testing
- `PYTHONPATH=src python -m ssl4polyp.classification.train_classification --exp-config exp/exp1_smoke.yaml --model-key sup_imnet --dataset-percent 10 --dataset-seed 13 --limit-train-batches 8 --limit-val-batches 4 --limit-test-batches 4 --roots data/roots.json --output-dir checkpoints/classification/exp1_smoke_sup_imnet_seed13` *(fails: missing dataset artifacts in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2d8a80e4832e88a3a4ba171c5ab1