### PR TITLE
Remove default SUN subset selection from exp4

### DIFF
--- a/config/exp/exp4.yaml
+++ b/config/exp/exp4.yaml
@@ -5,9 +5,6 @@ models:
   - model/sup_imnet
   - model/ssl_imnet
   - model/ssl_colon
-dataset:
-  percent: 100
-  seed: 47
 protocol:
   finetune: full
   eval_split: test


### PR DESCRIPTION
## Summary
- remove the hard-coded SUN subset percent and seed defaults from experiment 4 so the CLI-provided sweep values are used

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd4d940414832e9104d800c4433a77