### PR TITLE
Add helper for config-driven model lists

### DIFF
--- a/scripts/print_config_models.py
+++ b/scripts/print_config_models.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Print the canonical model keys for an experiment configuration."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+for path in (SRC_ROOT, REPO_ROOT):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+try:
+    from ssl4polyp.configs.layered import load_layered_config, resolve_model_entries
+except ModuleNotFoundError as exc:  # pragma: no cover - dependency issues
+    if exc.name in {"ssl4polyp", "yaml"}:
+        raise SystemExit(
+            "Unable to import required dependencies. Ensure PyYAML is installed and "
+            "the repository is available on PYTHONPATH before running this helper."
+        ) from exc
+    raise
+
+
+def _normalize_model_keys(raw: Iterable[dict]) -> List[str]:
+    keys: List[str] = []
+    for entry in raw:
+        key = entry.get("key")
+        if not key:
+            raise ValueError(f"Model entry missing 'key': {entry!r}")
+        keys.append(str(key))
+    return keys
+
+
+def _extract_models(config: dict) -> List[str]:
+    entries = config.get("models", []) or []
+    if not entries:
+        raise ValueError("Configuration does not define any models.")
+
+    resolved = resolve_model_entries(entries)
+    if not resolved:
+        raise ValueError("Configuration resolved to an empty model list.")
+
+    return _normalize_model_keys(resolved)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "config",
+        help=(
+            "Experiment configuration reference (e.g., 'exp/exp1.yaml'). "
+            "The path is resolved using the layered config loader."
+        ),
+    )
+    args = parser.parse_args()
+
+    cfg = load_layered_config(args.config)
+    models = _extract_models(cfg)
+    if not models:
+        raise SystemExit("Configuration does not define any models.")
+
+    print(" ".join(models))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_exp1.sh
+++ b/scripts/run_exp1.sh
@@ -7,8 +7,10 @@ EXP_CONFIG=${EXP_CONFIG:-exp/exp1.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+DEFAULT_MODELS=$("${SCRIPT_DIR}/print_config_models.py" "${EXP_CONFIG}")
 SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
-MODELS=${MODELS:-sup_imnet ssl_imnet}
+# Override MODELS in the environment to adjust the selection; defaults track the config.
+MODELS=${MODELS:-${DEFAULT_MODELS}}
 
 python - <<'PY'
 try:

--- a/scripts/run_exp1_smoke.sh
+++ b/scripts/run_exp1_smoke.sh
@@ -5,7 +5,9 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 EXP_CONFIG=${EXP_CONFIG:-exp/exp1_smoke.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
-MODELS=${MODELS:-sup_imnet}
+DEFAULT_MODELS=$("${SCRIPT_DIR}/print_config_models.py" "${EXP_CONFIG}")
+# Override MODELS in the environment to adjust the selection; defaults track the config.
+MODELS=${MODELS:-${DEFAULT_MODELS}}
 DATASET_PERCENT=${DATASET_PERCENT:-10}
 DATASET_SEED=${DATASET_SEED:-13}
 LIMIT_TRAIN=${LIMIT_TRAIN:-8}

--- a/scripts/run_exp2.sh
+++ b/scripts/run_exp2.sh
@@ -7,8 +7,10 @@ EXP_CONFIG=${EXP_CONFIG:-exp/exp2.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+DEFAULT_MODELS=$("${SCRIPT_DIR}/print_config_models.py" "${EXP_CONFIG}")
 SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
-MODELS=${MODELS:-ssl_imnet ssl_colon}
+# Override MODELS in the environment to adjust the selection; defaults track the config.
+MODELS=${MODELS:-${DEFAULT_MODELS}}
 
 python - <<'PY'
 import torch

--- a/scripts/run_exp3.sh
+++ b/scripts/run_exp3.sh
@@ -7,8 +7,10 @@ EXP_CONFIG=${EXP_CONFIG:-exp/exp3.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+DEFAULT_MODELS=$("${SCRIPT_DIR}/print_config_models.py" "${EXP_CONFIG}")
 SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
-MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
+# Override MODELS in the environment to adjust the selection; defaults track the config.
+MODELS=${MODELS:-${DEFAULT_MODELS}}
 
 python - <<'PY'
 import torch

--- a/scripts/run_exp4.sh
+++ b/scripts/run_exp4.sh
@@ -7,9 +7,11 @@ EXP_CONFIG=${EXP_CONFIG:-exp/exp4.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+DEFAULT_MODELS=$("${SCRIPT_DIR}/print_config_models.py" "${EXP_CONFIG}")
 SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
 PERCENTS=${PERCENTS:-5 10 25 50 100}
-MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
+# Override MODELS in the environment to adjust the selection; defaults track the config.
+MODELS=${MODELS:-${DEFAULT_MODELS}}
 
 python - <<'PY'
 import torch

--- a/scripts/run_exp5a.sh
+++ b/scripts/run_exp5a.sh
@@ -8,8 +8,10 @@ ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 PARENT_ROOT=${PARENT_ROOT:-checkpoints/classification}
 DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+DEFAULT_MODELS=$("${SCRIPT_DIR}/print_config_models.py" "${EXP_CONFIG}")
 SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
-MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
+# Override MODELS in the environment to adjust the selection; defaults track the config.
+MODELS=${MODELS:-${DEFAULT_MODELS}}
 
 # Canonical SUN fine-tuning checkpoints must be available prior to running this
 # script. The expected layout is:

--- a/scripts/run_exp5b.sh
+++ b/scripts/run_exp5b.sh
@@ -7,8 +7,10 @@ EXP_CONFIG=${EXP_CONFIG:-exp/exp5b.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+DEFAULT_MODELS=$("${SCRIPT_DIR}/print_config_models.py" "${EXP_CONFIG}")
 SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
-MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
+# Override MODELS in the environment to adjust the selection; defaults track the config.
+MODELS=${MODELS:-${DEFAULT_MODELS}}
 
 python - <<'PY'
 import torch

--- a/scripts/run_exp5c.sh
+++ b/scripts/run_exp5c.sh
@@ -7,9 +7,11 @@ EXP_CONFIG=${EXP_CONFIG:-exp/exp5c.yaml}
 ROOTS=${ROOTS:-data/roots.json}
 OUTPUT_ROOT=${OUTPUT_ROOT:-checkpoints/classification}
 DEFAULT_SEEDS=$("${SCRIPT_DIR}/print_config_seeds.py" "${EXP_CONFIG}")
+DEFAULT_MODELS=$("${SCRIPT_DIR}/print_config_models.py" "${EXP_CONFIG}")
 SEEDS=${SEEDS:-${DEFAULT_SEEDS}}
 SIZES=${SIZES:-50 100 200 500}
-MODELS=${MODELS:-sup_imnet ssl_imnet ssl_colon}
+# Override MODELS in the environment to adjust the selection; defaults track the config.
+MODELS=${MODELS:-${DEFAULT_MODELS}}
 
 python - <<'PY'
 import torch


### PR DESCRIPTION
## Summary
- add a print_config_models.py helper that resolves experiment configs and prints canonical model keys
- update experiment launcher scripts to use the helper so default MODELS lists track the configuration and document how to override them

## Testing
- not run (PyYAML dependency is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd5215a270832eab09f49a36041cb2