### PR TITLE
Restrict automatic morphology logging to experiment 3

### DIFF
--- a/tests/test_classification_eval_mode.py
+++ b/tests/test_classification_eval_mode.py
@@ -125,7 +125,7 @@ def test_cli_subset_overrides_and_batch_limits(monkeypatch, tmp_path):
 
     experiment_cfg = load_layered_config("exp/exp1_smoke.yaml")
     _, dataset_cfg, dataset_resolved = train_classification.apply_experiment_config(
-        args, experiment_cfg
+        args, experiment_cfg, resolved_overrides=None
     )
 
     assert dataset_cfg["name"] == "sun_subsets"


### PR DESCRIPTION
## Summary
- gate automatic morphology evaluation logging to configurations derived from experiment 3 or explicit overrides
- expose a `--morphology-eval` CLI flag so manual runs can request morphology-aware metrics without experiment defaults
- adjust experiment application helper tests for the new function signature

## Testing
- pytest tests/test_classification_eval_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68de334bf8b8832e91ca33e0b47b4742