### PR TITLE
Switch early stopping to monitor validation loss

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -8,7 +8,7 @@ scheduler:
   name: cosine
   warmup_epochs: 5
 early_stop:
-  monitor: val_auroc
+  monitor: val_loss
   patience: 10
 threshold_policy: youden
 seeds: [13, 29, 47]


### PR DESCRIPTION
## Summary
- update the shared base configuration to monitor validation loss for early stopping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded6389074832e9a9fcee46ade4fc9