### PR TITLE
Refactor report loaders to use shared helper

### DIFF
--- a/src/ssl4polyp/classification/analysis/common_loader.py
+++ b/src/ssl4polyp/classification/analysis/common_loader.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import csv
+import json
+import math
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, DefaultDict, Dict, Iterable, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .result_loader import ResultLoader
+
+__all__ = [
+    "CommonFrame",
+    "CommonRun",
+    "get_default_loader",
+    "load_common_run",
+    "load_outputs_csv",
+]
+
+
+@dataclass(frozen=True)
+class CommonFrame:
+    frame_id: str
+    case_id: str
+    prob: float
+    label: int
+    pred: int
+    row: Mapping[str, Any]
+
+
+@dataclass
+class CommonRun:
+    model: str
+    seed: int
+    tau: float
+    metrics_path: Path
+    outputs_path: Path
+    payload: Mapping[str, Any]
+    provenance: Mapping[str, Any]
+    primary_metrics: Dict[str, float]
+    frames: Tuple[CommonFrame, ...]
+    cases: Dict[str, Tuple[CommonFrame, ...]]
+
+
+def get_default_loader(*, strict: bool = True) -> ResultLoader:
+    return ResultLoader(
+        expected_primary_policy="f1_opt_on_val",
+        expected_sensitivity_policy="youden_on_val",
+        require_sensitivity=True,
+        strict=strict,
+    )
+
+
+def load_common_run(
+    metrics_path: Path,
+    *,
+    loader: Optional[ResultLoader] = None,
+) -> CommonRun:
+    payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+    normalised_payload = _normalise_payload(payload)
+    active_loader = loader or get_default_loader()
+    active_loader.validate(metrics_path, normalised_payload)
+    provenance_block = normalised_payload.get("provenance")
+    provenance = dict(provenance_block) if isinstance(provenance_block, Mapping) else {}
+    model_name = _clean_text(provenance.get("model")) or _infer_model_from_filename(metrics_path)
+    seed_value = _resolve_seed(normalised_payload, provenance, metrics_path)
+    primary_metrics = _extract_metrics(normalised_payload.get("test_primary"))
+    tau_value = primary_metrics.get("tau")
+    if tau_value is None:
+        raise ValueError(f"Metrics file '{metrics_path}' is missing test_primary.tau")
+    outputs_path = _resolve_outputs_path(metrics_path)
+    frames, cases = load_outputs_csv(outputs_path, tau=float(tau_value))
+    return CommonRun(
+        model=model_name,
+        seed=int(seed_value),
+        tau=float(tau_value),
+        metrics_path=metrics_path,
+        outputs_path=outputs_path,
+        payload=MappingProxyType(dict(normalised_payload)),
+        provenance=MappingProxyType(dict(provenance)),
+        primary_metrics=dict(primary_metrics),
+        frames=frames,
+        cases=cases,
+    )
+
+
+def load_outputs_csv(
+    outputs_path: Path,
+    *,
+    tau: float,
+) -> Tuple[Tuple[CommonFrame, ...], Dict[str, Tuple[CommonFrame, ...]]]:
+    if not outputs_path.exists():
+        raise FileNotFoundError(f"Missing test outputs CSV: {outputs_path}")
+    frames: list[CommonFrame] = []
+    cases: DefaultDict[str, list[CommonFrame]] = defaultdict(list)
+    with outputs_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for index, row in enumerate(reader):
+            row_data: Dict[str, Any] = {key: value for key, value in row.items()}
+            prob = _coerce_float(row_data.get("prob"))
+            label = _coerce_int(row_data.get("label"))
+            if prob is None or label is None:
+                continue
+            pred = _coerce_int(row_data.get("pred"))
+            if pred is None:
+                pred = 1 if float(prob) >= float(tau) else 0
+            case_id = _normalise_case_id(row_data.get("case_id") or row_data.get("sequence_id"), index)
+            frame_id = _normalise_frame_id(row_data.get("frame_id"), index)
+            frame = CommonFrame(
+                frame_id=frame_id,
+                case_id=case_id,
+                prob=float(prob),
+                label=int(label),
+                pred=int(pred),
+                row=MappingProxyType(dict(row_data)),
+            )
+            frames.append(frame)
+            cases[case_id].append(frame)
+    if not frames:
+        raise ValueError(f"No evaluation rows parsed from {outputs_path}")
+    return tuple(frames), {case: tuple(items) for case, items in cases.items()}
+
+
+def _normalise_payload(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    normalised: Dict[str, Any] = dict(payload)
+    test_primary = normalised.get("test_primary")
+    if not isinstance(test_primary, Mapping):
+        test_block = normalised.get("test")
+        if isinstance(test_block, Mapping):
+            normalised["test_primary"] = dict(test_block)
+    test_sensitivity = normalised.get("test_sensitivity")
+    if not isinstance(test_sensitivity, Mapping):
+        sensitivity_block = normalised.get("test_secondary")
+        if isinstance(sensitivity_block, Mapping):
+            normalised["test_sensitivity"] = dict(sensitivity_block)
+    return normalised
+
+
+def _extract_metrics(block: Optional[Mapping[str, Any]]) -> Dict[str, float]:
+    if not isinstance(block, Mapping):
+        return {}
+    metrics: Dict[str, float] = {}
+    for key, value in block.items():
+        numeric = _coerce_float(value)
+        if numeric is not None:
+            metrics[str(key)] = float(numeric)
+    return metrics
+
+
+def _resolve_outputs_path(metrics_path: Path) -> Path:
+    stem = metrics_path.stem
+    base = stem[:-5] if stem.endswith("_last") else stem
+    return metrics_path.with_name(f"{base}_test_outputs.csv")
+
+
+def _infer_model_from_filename(metrics_path: Path) -> str:
+    stem = metrics_path.stem
+    if stem.endswith("_last"):
+        stem = stem[:-5]
+    model = stem.split("__", 1)[0]
+    return model
+
+
+def _resolve_seed(
+    payload: Mapping[str, Any],
+    provenance: Mapping[str, Any],
+    metrics_path: Path,
+) -> int:
+    for candidate in (
+        _coerce_int(payload.get("seed")),
+        _coerce_int(provenance.get("train_seed")),
+        _seed_from_stem(metrics_path.stem),
+    ):
+        if candidate is not None:
+            return int(candidate)
+    raise ValueError(f"Metrics file '{metrics_path}' does not specify a seed")
+
+
+def _seed_from_stem(stem: str) -> Optional[int]:
+    match = re.search(r"_s(\d+)$", stem)
+    if match is None:
+        return None
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
+
+
+def _normalise_case_id(raw: Optional[object], index: int) -> str:
+    text = _clean_text(raw)
+    if text:
+        return text
+    return f"case_{index}"
+
+
+def _normalise_frame_id(raw: Optional[object], index: int) -> str:
+    text = _clean_text(raw)
+    if text:
+        return text
+    return f"frame_{index}"
+
+
+def _clean_text(value: Optional[object]) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _coerce_float(value: Optional[object]) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        numeric = float(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            numeric = float(text)
+        except ValueError:
+            return None
+    else:
+        return None
+    if not math.isfinite(numeric):
+        return None
+    return numeric
+
+
+def _coerce_int(value: Optional[object]) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, np.integer)):
+        return int(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return int(text)
+        except ValueError:
+            return None
+    return None
+

--- a/tests/classification/analysis/test_common_loader_guardrails.py
+++ b/tests/classification/analysis/test_common_loader_guardrails.py
@@ -1,0 +1,96 @@
+import csv
+import json
+from pathlib import Path
+
+import pytest  # type: ignore[import]
+
+from ssl4polyp.classification.analysis.common_loader import (  # type: ignore[import]
+    get_default_loader,
+    load_common_run,
+)
+from ssl4polyp.classification.analysis.result_loader import (  # type: ignore[import]
+    GuardrailViolation,
+)
+
+
+def _write_outputs(path: Path) -> None:
+    rows = [
+        {"frame_id": "f1", "case_id": "c1", "prob": 0.9, "label": 1},
+        {"frame_id": "f2", "case_id": "c2", "prob": 0.1, "label": 0},
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["frame_id", "case_id", "prob", "label"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _base_payload(*, tau: float = 0.5, digest: str = "deadbeef", policy: str = "f1_opt_on_val") -> dict[str, object]:
+    return {
+        "seed": 1,
+        "test_primary": {
+            "tau": tau,
+            "tp": 1,
+            "fp": 0,
+            "tn": 1,
+            "fn": 0,
+            "n_pos": 1,
+            "n_neg": 1,
+        },
+        "test_sensitivity": {
+            "tau": tau,
+            "tp": 1,
+            "fp": 0,
+            "tn": 1,
+            "fn": 0,
+            "n_pos": 1,
+            "n_neg": 1,
+        },
+        "thresholds": {
+            "primary": {"policy": policy, "tau": tau},
+            "sensitivity": {"policy": "youden_on_val", "tau": tau},
+        },
+        "provenance": {
+            "model": "ssl_colon",
+            "test_outputs_csv_sha256": digest,
+        },
+    }
+
+
+def _write_metrics(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _materialise_run(tmp_path: Path, payload: dict[str, object], stem: str = "run") -> Path:
+    metrics_path = tmp_path / f"{stem}.metrics.json"
+    outputs_path = tmp_path / f"{stem}_test_outputs.csv"
+    _write_outputs(outputs_path)
+    _write_metrics(metrics_path, payload)
+    return metrics_path
+
+
+def test_missing_thresholds_triggers_guardrail(tmp_path: Path) -> None:
+    payload = _base_payload()
+    payload.pop("thresholds", None)
+    metrics_path = _materialise_run(tmp_path, payload, stem="missing_thresholds")
+    loader = get_default_loader()
+    with pytest.raises(GuardrailViolation):
+        load_common_run(metrics_path, loader=loader)
+
+
+def test_digest_mismatch_across_runs(tmp_path: Path) -> None:
+    loader = get_default_loader()
+    first_path = _materialise_run(tmp_path, _base_payload(digest="aaaa"), stem="first")
+    load_common_run(first_path, loader=loader)
+    second_path = _materialise_run(tmp_path, _base_payload(digest="bbbb"), stem="second")
+    with pytest.raises(GuardrailViolation):
+        load_common_run(second_path, loader=loader)
+
+
+def test_primary_policy_mismatch(tmp_path: Path) -> None:
+    payload = _base_payload(policy="max_recall")
+    metrics_path = _materialise_run(tmp_path, payload, stem="bad_policy")
+    loader = get_default_loader()
+    with pytest.raises(GuardrailViolation):
+        load_common_run(metrics_path, loader=loader)

--- a/tests/test_exp5a_report.py
+++ b/tests/test_exp5a_report.py
@@ -80,6 +80,25 @@ def test_load_run_consumes_parent_metadata(tmp_path: Path) -> None:
             "auroc": 0.88,
             "f1": 0.7,
             "recall": 0.72,
+            "tp": 2,
+            "fp": 0,
+            "tn": 2,
+            "fn": 0,
+            "n_pos": 2,
+            "n_neg": 2,
+        },
+        "test_sensitivity": {
+            "tau": 0.5,
+            "tp": 2,
+            "fp": 0,
+            "tn": 2,
+            "fn": 0,
+            "n_pos": 2,
+            "n_neg": 2,
+        },
+        "thresholds": {
+            "primary": {"policy": "f1_opt_on_val", "tau": 0.5},
+            "sensitivity": {"policy": "youden_on_val", "tau": 0.5},
         },
         "domain_shift_delta": {
             "metrics": {
@@ -89,6 +108,7 @@ def test_load_run_consumes_parent_metadata(tmp_path: Path) -> None:
         },
         "provenance": {
             "model": "ssl_colon",
+            "test_outputs_csv_sha256": "deadbeef",
             "parent_run": {
                 "metrics": {
                     "path": "../sun_parent/seed1.metrics.json",
@@ -129,9 +149,29 @@ def test_summarize_runs_builds_expected_blocks(tmp_path: Path) -> None:
             "auroc": 0.9,
             "f1": 0.75,
             "recall": 0.78,
+            "tp": 2,
+            "fp": 0,
+            "tn": 2,
+            "fn": 0,
+            "n_pos": 2,
+            "n_neg": 2,
+        },
+        "test_sensitivity": {
+            "tau": 0.55,
+            "tp": 2,
+            "fp": 0,
+            "tn": 2,
+            "fn": 0,
+            "n_pos": 2,
+            "n_neg": 2,
+        },
+        "thresholds": {
+            "primary": {"policy": "f1_opt_on_val", "tau": 0.55},
+            "sensitivity": {"policy": "youden_on_val", "tau": 0.55},
         },
         "provenance": {
             "model": "ssl_colon",
+            "test_outputs_csv_sha256": "deadbeef",
             "parent_run": {
                 "metrics": {
                     "path": "../sun_parent/seed1.metrics.json",
@@ -148,9 +188,29 @@ def test_summarize_runs_builds_expected_blocks(tmp_path: Path) -> None:
             "auroc": 0.82,
             "f1": 0.68,
             "recall": 0.7,
+            "tp": 2,
+            "fp": 0,
+            "tn": 2,
+            "fn": 0,
+            "n_pos": 2,
+            "n_neg": 2,
+        },
+        "test_sensitivity": {
+            "tau": 0.6,
+            "tp": 2,
+            "fp": 0,
+            "tn": 2,
+            "fn": 0,
+            "n_pos": 2,
+            "n_neg": 2,
+        },
+        "thresholds": {
+            "primary": {"policy": "f1_opt_on_val", "tau": 0.6},
+            "sensitivity": {"policy": "youden_on_val", "tau": 0.6},
         },
         "provenance": {
             "model": "sup_imnet",
+            "test_outputs_csv_sha256": "deadbeef",
             "parent_run": {
                 "metrics": {
                     "path": "../sun_parent/seed1.metrics.json",


### PR DESCRIPTION
## Summary
- add a shared `common_loader` module that wraps `ResultLoader`, normalises metrics payloads, and builds frame/case structures
- update the exp3/exp5a/exp5c reports to consume the helper, removing bespoke CSV parsing while preserving morphology and few-shot extras
- extend and adjust the test suite, including new guardrail coverage, so fixtures satisfy the stricter loader expectations

## Testing
- pytest tests/test_exp3_report.py tests/test_exp5a_report.py tests/classification/analysis/test_common_loader_guardrails.py *(fails: missing optional numpy dependency and package import path)*

------
https://chatgpt.com/codex/tasks/task_e_68e67ee9afa0832eb8714905bb4b035f