### PR TITLE
Align PolypGen clean exports with fewshot metadata

### DIFF
--- a/src/ssl4polyp/classification/train_classification.py
+++ b/src/ssl4polyp/classification/train_classification.py
@@ -2792,11 +2792,14 @@ def _export_frame_outputs(
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     dataset_name_normalised = str(dataset_name or "").strip().lower()
-    is_polypgen_fewshot = dataset_name_normalised == "polypgen_fewshot"
+    is_polypgen_metadata_adjusted = dataset_name_normalised.startswith(
+        "polypgen_fewshot"
+    ) or dataset_name_normalised.startswith("polypgen_clean")
 
-    if is_polypgen_fewshot:
-        # exp5c evaluates polypgen_fewshot packs; adjust its exports without
-        # perturbing other PolypGen experiments that rely on case/morph columns.
+    if is_polypgen_metadata_adjusted:
+        # exp5-style evaluations export PolypGen metadata; adjust its exports
+        # without perturbing other PolypGen experiments that rely on case/morph
+        # columns.
         fieldnames = [
             "frame_id",
             "prob",
@@ -2853,7 +2856,7 @@ def _export_frame_outputs(
                 "origin": origin,
             }
 
-            if is_polypgen_fewshot:
+            if is_polypgen_metadata_adjusted:
                 case_id = _resolve_metadata_value(
                     row,
                     (

--- a/tests/test_polypgen_output_export.py
+++ b/tests/test_polypgen_output_export.py
@@ -4,6 +4,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
@@ -160,7 +162,20 @@ if "sklearn" not in sys.modules:
 from ssl4polyp.classification.train_classification import _export_frame_outputs
 
 
-def test_export_frame_outputs_polypgen_adjusts_columns(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "dataset_name",
+    [
+        "polypgen_fewshot",
+        "polypgen_fewshot_s50",
+        "PolypGen_FewShot_S200",
+        "polypgen_clean_test",
+        "polypgen_clean_test_extended",
+        "PolypGen_Clean_Test",
+    ],
+)
+def test_export_frame_outputs_polypgen_adjusts_columns(
+    tmp_path: Path, dataset_name: str
+) -> None:
     path = tmp_path / "polypgen.csv"
     metadata_rows = [
         {
@@ -184,7 +199,7 @@ def test_export_frame_outputs_polypgen_adjusts_columns(tmp_path: Path) -> None:
         probabilities=[0.9, 0.1],
         targets=[1, 0],
         preds=[1, 0],
-        dataset_name="polypgen_fewshot",
+        dataset_name=dataset_name,
     )
 
     with path.open(newline="", encoding="utf-8") as handle:
@@ -225,7 +240,7 @@ def test_export_frame_outputs_preserves_columns_for_other_datasets(tmp_path: Pat
         probabilities=[0.75],
         targets=[1],
         preds=[1],
-        dataset_name="polypgen_clean_test",
+        dataset_name="sun_test",
     )
 
     with path.open(newline="", encoding="utf-8") as handle:


### PR DESCRIPTION
## Summary
- extend the PolypGen output export adjustments to cover both few-shot and clean dataset variants
- broaden the regression test to include polypgen_clean dataset names and keep a non-PolypGen control case

## Testing
- pytest tests/test_polypgen_output_export.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e64f26bd8832ebcc1e4e6e498cb15)